### PR TITLE
Implement package group charge for plan

### DIFF
--- a/src/components/plans/ChargeGroupAccordion.tsx
+++ b/src/components/plans/ChargeGroupAccordion.tsx
@@ -280,7 +280,10 @@ export const ChargeGroupAccordion = memo(
               <SummaryLeft>
                 <Typography variant="bodyHl" color="textSecondary" noWrap>
                   {localChargeGroup?.invoiceDisplayName ||
-                    'Group ' + localChargeGroup?.id?.slice(19, 36)}
+                    'Group of ' +
+                      (formikProps.values.charges.find(
+                        (c) => c.chargeGroupId === localChargeGroup.id,
+                      )?.billableMetric.name || 'charges')}
                 </Typography>
                 <Tooltip title={translate('text_65018c8e5c6b626f030bcf8d')} placement="top-end">
                   <Button
@@ -565,7 +568,7 @@ export const ChargeGroupAccordion = memo(
           )}
 
           <InlineButtonsWrapper>
-            {!localCharge.payInAdvance && !showSpendingMinimum && (
+            {!localChargeGroup.payInAdvance && !showSpendingMinimum && (
               <Button
                 variant="quaternary"
                 startIcon="plus"

--- a/src/components/plans/ChargeGroupAccordion.tsx
+++ b/src/components/plans/ChargeGroupAccordion.tsx
@@ -348,12 +348,15 @@ export const ChargeGroupAccordion = memo(
                       e.stopPropagation()
                       e.preventDefault()
 
-                      // TODO: This is not working
                       const deleteChargeGroup = () => {
                         const chargeGroups = [...formikProps.values.chargeGroups]
+                        const removedChargeGroup = chargeGroups.splice(index, 1)[0]
+                        const updatedCharges = formikProps.values.charges.filter(
+                          (charge) => charge.chargeGroupId !== removedChargeGroup.id,
+                        )
 
-                        chargeGroups.splice(index, 1)
                         formikProps.setFieldValue('chargeGroups', chargeGroups)
+                        formikProps.setFieldValue('charges', updatedCharges)
                       }
 
                       if (actionType !== 'duplicate' && isUsedInSubscription) {

--- a/src/components/plans/ChargeGroupAccordion.tsx
+++ b/src/components/plans/ChargeGroupAccordion.tsx
@@ -329,8 +329,10 @@ export const ChargeGroupAccordion = memo(
         <PaddedChargesWrapper>
           <Charges>
             {formikProps.values.charges.map((charge, i) => {
+              const chargeGroupId = charge.chargeGroupId || charge.chargeGroup?.id
+
               // Prevent displaying charges from different charge groups
-              if (!charge.chargeGroupId || charge.chargeGroupId !== groupId) return
+              if (!chargeGroupId || chargeGroupId !== groupId) return
 
               const chargeId = getNewChargeId(charge.billableMetric.id, i)
 

--- a/src/components/plans/ChargeGroupAccordion.tsx
+++ b/src/components/plans/ChargeGroupAccordion.tsx
@@ -1,0 +1,684 @@
+import { gql } from '@apollo/client'
+import { InputAdornment } from '@mui/material'
+import { FormikProps } from 'formik'
+import { memo, MouseEvent, RefObject, useCallback, useEffect, useMemo, useState } from 'react'
+import styled from 'styled-components'
+
+import { Accordion, Button, Chip, Icon, Tooltip, Typography } from '~/components/designSystem'
+import { AmountInput, ButtonSelector, ComboBox, Switch } from '~/components/form'
+import { useDuplicatePlanVar } from '~/core/apolloClient'
+import {
+  FORM_TYPE_ENUM,
+  MUI_INPUT_BASE_ROOT_CLASSNAME,
+  SEARCH_GROUP_CHARGE_INPUT_CLASSNAME,
+} from '~/core/constants/form'
+import { getCurrencySymbol, intlFormatNumber } from '~/core/formats/intlFormatNumber'
+import getPropertyShape from '~/core/serializers/getPropertyShape'
+import {
+  AggregationTypeEnum,
+  ChargeModelEnum,
+  CurrencyEnum,
+  PlanInterval,
+  useGetMeteredBillableMetricsLazyQuery,
+} from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useCurrentUser } from '~/hooks/useCurrentUser'
+import { theme } from '~/styles'
+
+import { ChargeGroupChildAccordion } from './ChargeGroupChildAccordion'
+import { ChargeGroupOptionsAccordion } from './ChargeGroupOptionsAccordion'
+import { PackageGroupCharge } from './PackageGroupCharge'
+import { RemoveChargeWarningDialogRef } from './RemoveChargeWarningDialog'
+import { LocalChargeInput, PlanFormInput } from './types'
+
+import { Item } from '../form/ComboBox/ComboBoxItem'
+import { EditInvoiceDisplayNameRef } from '../invoices/EditInvoiceDisplayName'
+import { PremiumWarningDialogRef } from '../PremiumWarningDialog'
+
+const RESULT_LIMIT = 50
+
+gql`
+  fragment ChargeGroupAccordion on ChargeGroup {
+    id
+    invoiceDisplayName
+    invoiceable
+    minAmountCents
+    payInAdvance
+    properties {
+      amount
+    }
+    charges {
+      ...ChargeGroupChildAccordion
+    }
+  }
+`
+
+export const mapChargeIntervalCopy = (interval: string, forceMonthlyCharge: boolean): string => {
+  if (forceMonthlyCharge) {
+    return 'text_624453d52e945301380e49aa'
+  } else if (interval === PlanInterval.Monthly) {
+    return 'text_624453d52e945301380e49aa'
+  } else if (interval === PlanInterval.Yearly) {
+    return 'text_624453d52e945301380e49ac'
+  } else if (interval === PlanInterval.Quarterly) {
+    return 'text_64d6357b00dea100ad1cb9e9'
+  } else if (interval === PlanInterval.Weekly) {
+    return 'text_62b32ec6b0434070791c2d4c'
+  } else if (interval === PlanInterval.Daily) {
+    return 'Daily'
+  }
+
+  return ''
+}
+
+interface ChargeGroupAccordionProps {
+  currency: CurrencyEnum
+  disabled?: boolean
+  isInitiallyOpen?: boolean
+  isInSubscriptionForm?: boolean
+  formikProps: FormikProps<PlanFormInput>
+  idProps: string
+  index: number
+  isUsedInSubscription?: boolean
+  premiumWarningDialogRef?: RefObject<PremiumWarningDialogRef>
+  editInvoiceDisplayNameRef: RefObject<EditInvoiceDisplayNameRef>
+  removeChargeWarningDialogRef?: RefObject<RemoveChargeWarningDialogRef>
+  subscriptionFormType?: keyof typeof FORM_TYPE_ENUM
+}
+
+const getNewChargeId = (id: string, index: number) => `plan-charge-${id}-${index}`
+
+export const ChargeGroupAccordion = memo(
+  ({
+    currency,
+    disabled,
+    removeChargeWarningDialogRef,
+    premiumWarningDialogRef,
+    editInvoiceDisplayNameRef,
+    isUsedInSubscription,
+    isInitiallyOpen,
+    isInSubscriptionForm,
+    formikProps,
+    idProps,
+    index,
+    subscriptionFormType,
+  }: ChargeGroupAccordionProps) => {
+    const { translate } = useInternationalization()
+    const { isPremium } = useCurrentUser()
+    const { type: actionType } = useDuplicatePlanVar()
+    const chargeErrors = formikProps?.errors?.charges
+    const [showAddGroupCharge, setShowAddGroupCharge] = useState(false)
+
+    const [
+      getMeteredBillableMetrics,
+      { loading: meteredBillableMetricsLoading, data: meteredBillableMetricsData },
+    ] = useGetMeteredBillableMetricsLazyQuery({
+      fetchPolicy: 'network-only',
+      nextFetchPolicy: 'network-only',
+      variables: { limit: RESULT_LIMIT },
+    })
+    const meteredBillableMetrics = useMemo(() => {
+      if (
+        !meteredBillableMetricsData ||
+        !meteredBillableMetricsData?.billableMetrics ||
+        !meteredBillableMetricsData?.billableMetrics?.collection
+      )
+        return []
+
+      return meteredBillableMetricsData?.billableMetrics?.collection.map(({ id, name, code }) => {
+        return {
+          label: `${name} (${code})`,
+          labelNode: (
+            <Item>
+              <Typography color="grey700" noWrap>
+                {name}
+              </Typography>
+              &nbsp;
+              <Typography color="textPrimary" noWrap>
+                ({code})
+              </Typography>
+            </Item>
+          ),
+          value: id,
+        }
+      })
+    }, [meteredBillableMetricsData])
+
+    const { groupId, localChargeGroup, localCharge, initialLocalCharge, hasErrorInCharges } =
+      useMemo(() => {
+        return {
+          groupId: idProps,
+          localChargeGroup: formikProps.values.chargeGroups[index],
+          localCharge: formikProps.values.charges[index],
+          initialLocalCharge: formikProps.initialValues.charges[index],
+          hasDefaultPropertiesErrors:
+            typeof chargeErrors === 'object' &&
+            typeof chargeErrors[index] === 'object' &&
+            // @ts-ignore
+            typeof chargeErrors[index].properties === 'object',
+          hasErrorInCharges: Boolean(chargeErrors && chargeErrors[index]),
+        }
+      }, [
+        chargeErrors,
+        formikProps.initialValues.charges,
+        formikProps.values.chargeGroups,
+        formikProps.values.charges,
+        idProps,
+        index,
+      ])
+
+    const [showSpendingMinimum, setShowSpendingMinimum] = useState(
+      !!initialLocalCharge?.minAmountCents && Number(initialLocalCharge?.minAmountCents) > 0,
+    )
+
+    useEffect(() => {
+      setShowSpendingMinimum(
+        !!initialLocalCharge?.minAmountCents && Number(initialLocalCharge?.minAmountCents) > 0,
+      )
+    }, [initialLocalCharge?.minAmountCents])
+
+    const handleUpdate = useCallback(
+      (name: string, value: unknown) => {
+        if (name === 'chargeModel') {
+          // IMPORTANT: This check should stay first in this function
+          // If user is not premium and try to switch to graduated percentage pricing
+          // We should show the premium modal and prevent any formik value change
+          if (!isPremium && value === ChargeModelEnum.GraduatedPercentage) {
+            premiumWarningDialogRef?.current?.openDialog()
+            return
+          }
+
+          // Reset pay in advance when switching charge model
+          if (
+            (value === ChargeModelEnum.Graduated && localCharge.payInAdvance) ||
+            value === ChargeModelEnum.Volume ||
+            localCharge.billableMetric.aggregationType === AggregationTypeEnum.MaxAgg ||
+            localCharge.billableMetric.aggregationType === AggregationTypeEnum.LatestAgg ||
+            localCharge.billableMetric.aggregationType === AggregationTypeEnum.WeightedSumAgg
+          ) {
+            formikProps.setFieldValue(`charges.${index}.payInAdvance`, false)
+          }
+
+          // Reset prorated when switching charge model
+          if (
+            (localCharge.billableMetric.recurring && value === ChargeModelEnum.Graduated) ||
+            localCharge.billableMetric.aggregationType === AggregationTypeEnum.WeightedSumAgg ||
+            value === ChargeModelEnum.GraduatedPercentage ||
+            value === ChargeModelEnum.Package ||
+            value === ChargeModelEnum.Percentage
+          ) {
+            formikProps.setFieldValue(`charges.${index}.prorated`, false)
+          }
+        }
+
+        if (name === 'payInAdvance') {
+          if (value === true) {
+            // Pay in advance
+            formikProps.setFieldValue(`charges.${index}.minAmountCents`, undefined)
+
+            if (localCharge.chargeModel === ChargeModelEnum.Graduated) {
+              formikProps.setFieldValue(`charges.${index}.prorated`, false)
+            }
+          } else {
+            // Pay in arrears
+            formikProps.setFieldValue(`charges.${index}.invoiceable`, true)
+          }
+        }
+
+        formikProps.setFieldValue(`charges.${index}.${name}`, value)
+      },
+
+      [
+        formikProps,
+        index,
+        isPremium,
+        localCharge.billableMetric.aggregationType,
+        localCharge.billableMetric.recurring,
+        localCharge.payInAdvance,
+        localCharge.chargeModel,
+        premiumWarningDialogRef,
+      ],
+    )
+
+    const taxValueForBadgeDisplay = useMemo((): string | undefined => {
+      if (!localCharge?.taxes?.length && !formikProps?.values?.taxes?.length) return
+
+      if (localCharge.taxes?.length)
+        return String(localCharge.taxes.reduce((acc, cur) => acc + cur.rate, 0))
+
+      return String(formikProps?.values?.taxes?.reduce((acc, cur) => acc + cur.rate, 0))
+    }, [formikProps?.values?.taxes, localCharge.taxes])
+
+    const chargePayInAdvanceSwitchHelperText = useMemo(() => {
+      if (localCharge.chargeModel === ChargeModelEnum.Volume) {
+        return translate('text_646e2d0cc536351b62ba6fc0')
+      } else if (localCharge.billableMetric.aggregationType === AggregationTypeEnum.MaxAgg) {
+        return translate('text_646e2d0cc536351b62ba6f48')
+      } else if (localCharge.payInAdvance) {
+        return translate('text_646e2d0cc536351b62ba6f12')
+      }
+
+      // Charge paid in arrears
+      return translate('text_646e2d0cc536351b62ba6f53')
+    }, [
+      localCharge.chargeModel,
+      localCharge.payInAdvance,
+      localCharge.billableMetric.aggregationType,
+      translate,
+    ])
+
+    return (
+      <Accordion
+        noContentMargin
+        id={idProps}
+        initiallyOpen={
+          isInitiallyOpen || !formikProps.values.chargeGroups?.[index]?.id ? true : false
+        }
+        summary={
+          <Summary>
+            <ChargeSummaryLeftWrapper>
+              <SummaryLeft>
+                <Typography variant="bodyHl" color="textSecondary" noWrap>
+                  {localChargeGroup?.invoiceDisplayName ||
+                    'Group ' + localChargeGroup?.id?.slice(19, 36)}
+                </Typography>
+                <Tooltip title={translate('text_65018c8e5c6b626f030bcf8d')} placement="top-end">
+                  <Button
+                    icon="pen"
+                    variant="quaternary"
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation()
+
+                      editInvoiceDisplayNameRef.current?.openDialog({
+                        invoiceDisplayName: localChargeGroup.invoiceDisplayName,
+                        callback: (invoiceDisplayName: string) => {
+                          formikProps.setFieldValue(
+                            `chargeGroups.${index}.invoiceDisplayName`,
+                            invoiceDisplayName,
+                          )
+                        },
+                      })
+                    }}
+                  />
+                </Tooltip>
+              </SummaryLeft>
+            </ChargeSummaryLeftWrapper>
+            <SummaryRight>
+              <Tooltip
+                placement="top-end"
+                title={
+                  hasErrorInCharges
+                    ? translate('text_635b975ecea4296eb76924b7')
+                    : translate('text_635b975ecea4296eb76924b1')
+                }
+              >
+                <ValidationIcon
+                  name="validate-filled"
+                  color={hasErrorInCharges ? 'disabled' : 'success'}
+                />
+              </Tooltip>
+
+              {!!taxValueForBadgeDisplay && (
+                <Chip
+                  label={intlFormatNumber(Number(taxValueForBadgeDisplay) / 100 || 0, {
+                    minimumFractionDigits: 2,
+                    style: 'percent',
+                  })}
+                />
+              )}
+              <Chip
+                label={translate(
+                  mapChargeIntervalCopy(
+                    formikProps.values.interval,
+                    (formikProps.values.interval === PlanInterval.Yearly &&
+                      !!formikProps.values.billChargesMonthly) ||
+                      false,
+                  ),
+                )}
+              />
+              {!isInSubscriptionForm && (
+                <Tooltip placement="top-end" title={translate('text_624aa732d6af4e0103d40e65')}>
+                  <Button
+                    variant="quaternary"
+                    size="small"
+                    icon="trash"
+                    data-test="remove-charge"
+                    onClick={(e: MouseEvent<HTMLButtonElement>) => {
+                      e.stopPropagation()
+                      e.preventDefault()
+
+                      // TODO: This is not working
+                      const deleteChargeGroup = () => {
+                        const chargeGroups = [...formikProps.values.chargeGroups]
+
+                        chargeGroups.splice(index, 1)
+                        formikProps.setFieldValue('chargeGroups', chargeGroups)
+                      }
+
+                      if (actionType !== 'duplicate' && isUsedInSubscription) {
+                        removeChargeWarningDialogRef?.current?.openDialog(index)
+                      } else {
+                        deleteChargeGroup()
+                      }
+                    }}
+                  />
+                </Tooltip>
+              )}
+            </SummaryRight>
+          </Summary>
+        }
+        data-test={`charge-accordion-${index}`}
+      >
+        {/* Charge group amount input */}
+        <PaddedChargesWrapper>
+          <PackageGroupCharge
+            chargeGroupIndex={index}
+            currency={currency}
+            disabled={disabled}
+            formikProps={formikProps}
+            propertyCursor="properties"
+            valuePointer={localChargeGroup.properties}
+          />
+        </PaddedChargesWrapper>
+
+        <PaddedChargesWrapper>
+          <Charges>
+            {formikProps.values.charges.map((charge, i) => {
+              // Prevent displaying charges from different charge groups
+              if (!charge.chargeGroupId || charge.chargeGroupId !== groupId) return
+
+              const chargeId = getNewChargeId(charge.billableMetric.id, i)
+
+              return (
+                <ChargeGroupChildAccordion
+                  id={chargeId}
+                  key={chargeId}
+                  isInitiallyOpen={!isInitiallyOpen}
+                  isInSubscriptionForm={isInSubscriptionForm}
+                  subscriptionFormType={subscriptionFormType}
+                  removeChargeWarningDialogRef={removeChargeWarningDialogRef}
+                  premiumWarningDialogRef={premiumWarningDialogRef}
+                  editInvoiceDisplayNameRef={editInvoiceDisplayNameRef}
+                  isUsedInSubscription={false}
+                  currency={formikProps.values.amountCurrency || CurrencyEnum.Usd}
+                  index={i}
+                  disabled={false}
+                  formikProps={formikProps}
+                />
+              )
+            })}
+          </Charges>
+
+          {/* Add a child charge button */}
+          {!!showAddGroupCharge && (
+            <AddChargeInlineWrapper>
+              <ComboBox
+                className={SEARCH_GROUP_CHARGE_INPUT_CLASSNAME}
+                data={meteredBillableMetrics}
+                searchQuery={getMeteredBillableMetrics}
+                loading={meteredBillableMetricsLoading}
+                placeholder={translate('text_6435888d7cc86500646d8981')}
+                emptyText={translate('text_6246b6bc6b25f500b779aa7a')}
+                onChange={(newCharge) => {
+                  const previousCharges = [...formikProps.values.charges]
+                  // const newId = getNewChargeId(newCharge, previousCharges.length)
+                  const localBillableMetrics =
+                    meteredBillableMetricsData?.billableMetrics?.collection.find(
+                      (bm) => bm.id === newCharge,
+                    )
+                  const lastMeteredIndex = previousCharges.findLastIndex(
+                    (c) => c.billableMetric.recurring === false,
+                  )
+                  const newChargeIndex = lastMeteredIndex < 0 ? 0 : lastMeteredIndex + 1
+
+                  previousCharges.splice(newChargeIndex, 0, {
+                    payInAdvance: true,
+                    invoiceable: true,
+                    billableMetric: localBillableMetrics,
+                    properties: getPropertyShape({}),
+                    groupProperties: localBillableMetrics?.flatGroups?.length ? [] : undefined,
+                    chargeModel: ChargeModelEnum.PackageGroup,
+                    amountCents: undefined,
+                    chargeGroupId: groupId,
+                  } as LocalChargeInput)
+
+                  formikProps.setFieldValue('charges', previousCharges)
+
+                  setShowAddGroupCharge(false)
+                  // newChargeId.current = newId
+                }}
+              />
+              <Tooltip placement="top-end" title={translate('text_63aa085d28b8510cd46443ff')}>
+                <Button
+                  icon="trash"
+                  variant="quaternary"
+                  onClick={() => {
+                    setShowAddGroupCharge(false)
+                  }}
+                />
+              </Tooltip>
+            </AddChargeInlineWrapper>
+          )}
+          {!isInSubscriptionForm && (
+            <InlineButtons>
+              <Button
+                startIcon="plus"
+                variant="quaternary"
+                data-test="add-group-charge-item"
+                onClick={() => {
+                  setShowAddGroupCharge(true)
+                  setTimeout(() => {
+                    ;(
+                      document.querySelector(
+                        `.${SEARCH_GROUP_CHARGE_INPUT_CLASSNAME} .${MUI_INPUT_BASE_ROOT_CLASSNAME}`,
+                      ) as HTMLElement
+                    )?.click()
+                  }, 0)
+                }}
+              >
+                {translate('Add a charge item')}
+              </Button>
+            </InlineButtons>
+          )}
+        </PaddedChargesWrapper>
+
+        {/* Charge options */}
+        <ChargeGroupOptionsAccordion chargeGroup={localChargeGroup} currency={currency}>
+          <ButtonSelector
+            label={translate('text_646e2d0cc536351b62ba6f1a')}
+            disabled={isInSubscriptionForm || disabled}
+            helperText={chargePayInAdvanceSwitchHelperText}
+            onChange={(value) => handleUpdate('payInAdvance', Boolean(value))}
+            value={localChargeGroup?.payInAdvance || true}
+            options={[
+              // NOTE: For now, charge group is pay in advance by default
+              {
+                label: translate('text_646e2d0cc536351b62ba6f2b'),
+                value: false,
+                disabled: true,
+              },
+              {
+                label: translate('text_646e2d0cc536351b62ba6f3d'),
+                value: true,
+                disabled: true,
+              },
+            ]}
+          />
+
+          {localChargeGroup?.payInAdvance && (
+            <InvoiceableSwitchWrapper>
+              <Switch
+                name={`charge-${localChargeGroup?.id}-invoiceable`}
+                label={translate('text_646e2d0cc536351b62ba6f25')}
+                disabled={isInSubscriptionForm || disabled}
+                subLabel={translate('text_646e2d0cc536351b62ba6f35')}
+                checked={!!localChargeGroup?.invoiceable}
+                onChange={(value) => {
+                  if (isPremium) {
+                    handleUpdate('invoiceable', value)
+                  } else {
+                    premiumWarningDialogRef?.current?.openDialog()
+                  }
+                }}
+              />
+              {!isPremium && <Icon name="sparkles" />}
+            </InvoiceableSwitchWrapper>
+          )}
+          {!localChargeGroup?.payInAdvance && !!showSpendingMinimum && (
+            <SpendingMinimumWrapper>
+              <>
+                <SpendingMinimumInput
+                  id={`spending-minimum-input-${index}`}
+                  beforeChangeFormatter={['positiveNumber', 'chargeDecimal']}
+                  label={translate('text_643e592657fc1ba5ce110c30')}
+                  currency={currency}
+                  placeholder={translate('text_643e592657fc1ba5ce110c80')}
+                  disabled={subscriptionFormType === FORM_TYPE_ENUM.edition || disabled}
+                  value={localChargeGroup.minAmountCents}
+                  onChange={(value) => handleUpdate('minAmountCents', value)}
+                  InputProps={{
+                    endAdornment: (
+                      <InputAdornment position="end">{getCurrencySymbol(currency)}</InputAdornment>
+                    ),
+                  }}
+                />
+                <CloseDescriptionTooltip
+                  placement="top-end"
+                  title={translate('text_63aa085d28b8510cd46443ff')}
+                >
+                  <Button
+                    icon="trash"
+                    variant="quaternary"
+                    disabled={disabled}
+                    onClick={() => {
+                      formikProps.setFieldValue(`charges.${index}.minAmountCents`, null)
+                      setShowSpendingMinimum(false)
+                    }}
+                  />
+                </CloseDescriptionTooltip>
+              </>
+            </SpendingMinimumWrapper>
+          )}
+
+          <InlineButtonsWrapper>
+            {!localCharge.payInAdvance && !showSpendingMinimum && (
+              <Button
+                variant="quaternary"
+                startIcon="plus"
+                disabled={subscriptionFormType === FORM_TYPE_ENUM.edition || disabled}
+                endIcon={isPremium ? undefined : 'sparkles'}
+                onClick={() => {
+                  if (isPremium) {
+                    setShowSpendingMinimum(true)
+                    setTimeout(() => {
+                      document.getElementById(`spending-minimum-input-${index}`)?.focus()
+                    }, 0)
+                  } else {
+                    premiumWarningDialogRef?.current?.openDialog()
+                  }
+                }}
+              >
+                {translate('text_643e592657fc1ba5ce110b9e')}
+              </Button>
+            )}
+          </InlineButtonsWrapper>
+        </ChargeGroupOptionsAccordion>
+      </Accordion>
+    )
+  },
+)
+
+ChargeGroupAccordion.displayName = 'ChargeGroupAccordion'
+
+const ValidationIcon = styled(Icon)`
+  display: flex;
+  align-items: center;
+`
+
+const SummaryLeft = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing(2)};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`
+
+const SummaryRight = styled.div`
+  display: flex;
+  align-items: center;
+  > *:not(:last-child) {
+    margin-right: ${theme.spacing(3)};
+  }
+`
+
+const SpendingMinimumWrapper = styled.div`
+  display: flex;
+`
+
+const SpendingMinimumInput = styled(AmountInput)`
+  flex: 1;
+  margin-right: ${theme.spacing(3)};
+`
+
+const CloseDescriptionTooltip = styled(Tooltip)`
+  margin-top: ${theme.spacing(7)};
+`
+
+const InvoiceableSwitchWrapper = styled.div`
+  display: flex;
+  align-items: center;
+
+  > *:first-child {
+    flex: 1;
+  }
+`
+
+const InlineButtonsWrapper = styled.div`
+  display: flex;
+`
+
+const Summary = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: ${theme.spacing(3)};
+  overflow: hidden;
+`
+
+const ChargeSummaryLeftWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`
+
+const Charges = styled.div`
+  > *:not(:last-child) {
+    margin-bottom: ${theme.spacing(6)};
+  }
+`
+
+const PaddedChargesWrapper = styled.div`
+  margin-top: ${theme.spacing(4)};
+  padding: 0 ${theme.spacing(4)} ${theme.spacing(4)};
+  box-sizing: border-box;
+  box-shadow: ${theme.shadows[7]};
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing(4)};
+`
+
+const InlineButtons = styled.div`
+  display: flex;
+`
+
+const AddChargeInlineWrapper = styled.div`
+  > :first-child {
+    flex: 1;
+    margin-right: ${theme.spacing(3)};
+  }
+
+  display: flex;
+  align-items: center;
+`

--- a/src/components/plans/ChargeGroupChildAccordion.tsx
+++ b/src/components/plans/ChargeGroupChildAccordion.tsx
@@ -1,0 +1,734 @@
+import { gql } from '@apollo/client'
+import { FormikProps } from 'formik'
+import { memo, MouseEvent, RefObject, useCallback, useMemo, useState } from 'react'
+import styled from 'styled-components'
+
+import { Accordion, Button, Icon, Tooltip, Typography } from '~/components/designSystem'
+import { ComboBox } from '~/components/form'
+import { useDuplicatePlanVar } from '~/core/apolloClient'
+import {
+  FORM_TYPE_ENUM,
+  MUI_INPUT_BASE_ROOT_CLASSNAME,
+  SEARCH_CHARGE_GROUP_INPUT_CLASSNAME,
+} from '~/core/constants/form'
+import getPropertyShape from '~/core/serializers/getPropertyShape'
+import {
+  AggregationTypeEnum,
+  ChargeForChargeGroupOptionsAccordionFragmentDoc,
+  ChargeModelEnum,
+  CurrencyEnum,
+  PackageGroupChargeFragmentDoc,
+  PlanInterval,
+  TimebasedChargeFragmentDoc,
+} from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { useCurrentUser } from '~/hooks/useCurrentUser'
+import { theme } from '~/styles'
+
+import { ChargeWrapperSwitch } from './ChargeWrapperSwitch'
+import { RemoveChargeWarningDialogRef } from './RemoveChargeWarningDialog'
+import { PlanFormInput } from './types'
+
+import { ConditionalWrapper } from '../ConditionalWrapper'
+import { EditInvoiceDisplayNameRef } from '../invoices/EditInvoiceDisplayName'
+import { PremiumWarningDialogRef } from '../PremiumWarningDialog'
+
+const DEFAULT_GROUP_VALUE = 'DEFAULT'
+
+gql`
+  fragment ChargeGroupChildAccordion on Charge {
+    id
+    chargeModel
+    invoiceable
+    minAmountCents
+    payInAdvance
+    prorated
+    invoiceDisplayName
+    properties {
+      amount
+    }
+    groupProperties {
+      groupId
+      invoiceDisplayName
+      values {
+        amount
+      }
+    }
+    billableMetric {
+      id
+      name
+      aggregationType
+      recurring
+      flatGroups {
+        id
+        key
+        value
+      }
+    }
+    taxes {
+      ...TaxForPlanChargeAccordion
+    }
+    ...ChargeForChargeGroupOptionsAccordion
+    ...PackageGroupCharge
+    ...TimebasedCharge
+  }
+
+  ${ChargeForChargeGroupOptionsAccordionFragmentDoc}
+  ${PackageGroupChargeFragmentDoc}
+  ${TimebasedChargeFragmentDoc}
+`
+
+export const mapChargeIntervalCopy = (interval: string, forceMonthlyCharge: boolean): string => {
+  if (forceMonthlyCharge) {
+    return 'text_624453d52e945301380e49aa'
+  } else if (interval === PlanInterval.Monthly) {
+    return 'text_624453d52e945301380e49aa'
+  } else if (interval === PlanInterval.Yearly) {
+    return 'text_624453d52e945301380e49ac'
+  } else if (interval === PlanInterval.Quarterly) {
+    return 'text_64d6357b00dea100ad1cb9e9'
+  } else if (interval === PlanInterval.Weekly) {
+    return 'text_62b32ec6b0434070791c2d4c'
+  } else if (interval === PlanInterval.Daily) {
+    return 'Daily'
+  }
+
+  return ''
+}
+
+interface ChargeAccordionProps {
+  currency: CurrencyEnum
+  disabled?: boolean
+  isInitiallyOpen?: boolean
+  isInSubscriptionForm?: boolean
+  formikProps: FormikProps<PlanFormInput>
+  id: string
+  index: number
+  isUsedInSubscription?: boolean
+  premiumWarningDialogRef?: RefObject<PremiumWarningDialogRef>
+  editInvoiceDisplayNameRef: RefObject<EditInvoiceDisplayNameRef>
+  removeChargeWarningDialogRef?: RefObject<RemoveChargeWarningDialogRef>
+  subscriptionFormType?: keyof typeof FORM_TYPE_ENUM
+}
+
+export const ChargeGroupChildAccordion = memo(
+  ({
+    currency,
+    disabled,
+    removeChargeWarningDialogRef,
+    premiumWarningDialogRef,
+    editInvoiceDisplayNameRef,
+    isUsedInSubscription,
+    isInitiallyOpen,
+    isInSubscriptionForm,
+    formikProps,
+    id,
+    index,
+  }: ChargeAccordionProps) => {
+    const { translate } = useInternationalization()
+    const { isPremium } = useCurrentUser()
+    const { type: actionType } = useDuplicatePlanVar()
+    const chargeErrors = formikProps?.errors?.charges
+
+    const { localCharge, hasDefaultPropertiesErrors, hasErrorInCharges } = useMemo(() => {
+      return {
+        localCharge: formikProps.values.charges[index],
+        hasDefaultPropertiesErrors:
+          typeof chargeErrors === 'object' &&
+          typeof chargeErrors[index] === 'object' &&
+          // @ts-ignore
+          typeof chargeErrors[index].properties === 'object',
+        hasErrorInCharges: Boolean(chargeErrors && chargeErrors[index]),
+      }
+    }, [chargeErrors, formikProps.values.charges, index])
+
+    const localChargeExistingGroupPropertiesIds =
+      localCharge?.groupProperties?.map((g) => g.groupId) || []
+
+    const [showAddGroup, setShowAddGroup] = useState(false)
+
+    const handleUpdate = useCallback(
+      (name: string, value: unknown) => {
+        if (name === 'chargeModel') {
+          // IMPORTANT: This check should stay first in this function
+          // If user is not premium and try to switch to graduated percentage pricing
+          // We should show the premium modal and prevent any formik value change
+          if (!isPremium && value === ChargeModelEnum.GraduatedPercentage) {
+            premiumWarningDialogRef?.current?.openDialog()
+            return
+          }
+
+          // Reset pay in advance when switching charge model
+          if (
+            (value === ChargeModelEnum.Graduated && localCharge.payInAdvance) ||
+            value === ChargeModelEnum.Volume ||
+            localCharge.billableMetric.aggregationType === AggregationTypeEnum.MaxAgg ||
+            localCharge.billableMetric.aggregationType === AggregationTypeEnum.LatestAgg ||
+            localCharge.billableMetric.aggregationType === AggregationTypeEnum.WeightedSumAgg
+          ) {
+            formikProps.setFieldValue(`charges.${index}.payInAdvance`, false)
+          }
+
+          // Reset prorated when switching charge model
+          if (
+            (localCharge.billableMetric.recurring && value === ChargeModelEnum.Graduated) ||
+            localCharge.billableMetric.aggregationType === AggregationTypeEnum.WeightedSumAgg ||
+            value === ChargeModelEnum.GraduatedPercentage ||
+            value === ChargeModelEnum.Package ||
+            value === ChargeModelEnum.Percentage
+          ) {
+            formikProps.setFieldValue(`charges.${index}.prorated`, false)
+          }
+        }
+
+        if (name === 'payInAdvance') {
+          if (value === true) {
+            // Pay in advance
+            formikProps.setFieldValue(`charges.${index}.minAmountCents`, undefined)
+
+            if (localCharge.chargeModel === ChargeModelEnum.Graduated) {
+              formikProps.setFieldValue(`charges.${index}.prorated`, false)
+            }
+          } else {
+            // Pay in arrears
+            formikProps.setFieldValue(`charges.${index}.invoiceable`, true)
+          }
+        }
+
+        formikProps.setFieldValue(`charges.${index}.${name}`, value)
+      },
+
+      [
+        formikProps,
+        index,
+        isPremium,
+        localCharge.billableMetric.aggregationType,
+        localCharge.billableMetric.recurring,
+        localCharge.payInAdvance,
+        localCharge.chargeModel,
+        premiumWarningDialogRef,
+      ],
+    )
+
+    return (
+      <Accordion
+        noContentMargin
+        id={id}
+        initiallyOpen={isInitiallyOpen ? true : false}
+        summary={
+          <Summary>
+            <ChargeSummaryLeftWrapper>
+              <SummaryLeft>
+                <Typography variant="bodyHl" color="textSecondary" noWrap>
+                  {localCharge.invoiceDisplayName || localCharge?.billableMetric?.name}
+                </Typography>
+                <Tooltip title={translate('text_65018c8e5c6b626f030bcf8d')} placement="top-end">
+                  <Button
+                    icon="pen"
+                    variant="quaternary"
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation()
+
+                      editInvoiceDisplayNameRef.current?.openDialog({
+                        invoiceDisplayName: localCharge.invoiceDisplayName,
+                        callback: (invoiceDisplayName: string) => {
+                          formikProps.setFieldValue(
+                            `charges.${index}.invoiceDisplayName`,
+                            invoiceDisplayName,
+                          )
+                        },
+                      })
+                    }}
+                  />
+                </Tooltip>
+              </SummaryLeft>
+              <Typography variant="caption" noWrap>
+                {localCharge?.billableMetric?.code}
+              </Typography>
+            </ChargeSummaryLeftWrapper>
+            <SummaryRight>
+              <Tooltip
+                placement="top-end"
+                title={
+                  hasErrorInCharges
+                    ? translate('text_635b975ecea4296eb76924b7')
+                    : translate('text_635b975ecea4296eb76924b1')
+                }
+              >
+                <ValidationIcon
+                  name="validate-filled"
+                  color={hasErrorInCharges ? 'disabled' : 'success'}
+                />
+              </Tooltip>
+
+              {!isInSubscriptionForm && (
+                <Tooltip placement="top-end" title={translate('text_624aa732d6af4e0103d40e65')}>
+                  <Button
+                    variant="quaternary"
+                    size="small"
+                    icon="trash"
+                    data-test="remove-charge"
+                    onClick={(e: MouseEvent<HTMLButtonElement>) => {
+                      e.stopPropagation()
+                      e.preventDefault()
+
+                      // TODO: This is not working
+                      const deleteCharge = () => {
+                        const charges = [...formikProps.values.charges]
+
+                        charges.splice(index, 1)
+
+                        formikProps.setFieldValue('charges', charges)
+                      }
+
+                      if (actionType !== 'duplicate' && isUsedInSubscription) {
+                        removeChargeWarningDialogRef?.current?.openDialog(index)
+                      } else {
+                        deleteCharge()
+                      }
+                    }}
+                  />
+                </Tooltip>
+              )}
+            </SummaryRight>
+          </Summary>
+        }
+        data-test={`charge-accordion-${index}`}
+      >
+        <>
+          {/* Charge main infos */}
+          <ChargeModelWrapper data-test="charge-model-wrapper">
+            <ComboBox
+              disableClearable
+              sortValues={false}
+              name="chargeModel"
+              disabled={isInSubscriptionForm || disabled}
+              label={
+                <InlineComboboxLabel>
+                  <Typography variant="captionHl" color="textSecondary">
+                    {translate('text_624c5eadff7db800acc4ca0d')}
+                  </Typography>
+                </InlineComboboxLabel>
+              }
+              data={[
+                {
+                  label: translate('Package pricing'),
+                  value: ChargeModelEnum.PackageGroup,
+                },
+                {
+                  label: 'Time-based pricing',
+                  value: ChargeModelEnum.Timebased,
+                },
+              ]}
+              value={localCharge.chargeModel}
+              helperText={translate(
+                localCharge.chargeModel === ChargeModelEnum.PackageGroup
+                  ? 'For example, user is allowed to use 100 units of this package.'
+                  : localCharge.chargeModel === ChargeModelEnum.Timebased
+                    ? ''
+                    : 'text_624d9adba93343010cd14ca7',
+              )}
+              onChange={(value) => handleUpdate('chargeModel', value)}
+            />
+          </ChargeModelWrapper>
+
+          <AllChargesWrapper
+            $hasGroupDisplay={!!localCharge.billableMetric.flatGroups?.length}
+            $hasChargesToDisplay={
+              !!localCharge?.properties || !!localCharge?.groupProperties?.length
+            }
+          >
+            {/* Simple charge or default property for groups */}
+            {!!localCharge.properties && (
+              <ConditionalWrapper
+                condition={!!localCharge.billableMetric.flatGroups?.length}
+                invalidWrapper={(children) => (
+                  <div data-test="default-charge-accordion-without-group">{children}</div>
+                )}
+                validWrapper={(children) => (
+                  <Accordion
+                    noContentMargin
+                    summary={
+                      <Summary>
+                        <Title>
+                          <Typography variant="bodyHl" color="textSecondary" noWrap>
+                            {translate('text_64e620bca31226337ffc62ad')}
+                          </Typography>
+                          <Typography variant="caption" noWrap>
+                            {translate('text_64e620bca31226337ffc62af')}
+                          </Typography>
+                        </Title>
+                        <SummaryRight>
+                          <Tooltip
+                            placement="top-end"
+                            title={
+                              hasDefaultPropertiesErrors
+                                ? translate('text_635b975ecea4296eb76924b7')
+                                : translate('text_635b975ecea4296eb76924b1')
+                            }
+                          >
+                            <ValidationIcon
+                              name="validate-filled"
+                              color={hasDefaultPropertiesErrors ? 'disabled' : 'success'}
+                            />
+                          </Tooltip>
+                          <Tooltip
+                            placement="top-end"
+                            title={translate('text_63aa085d28b8510cd46443ff')}
+                          >
+                            <Button
+                              size="small"
+                              icon="trash"
+                              variant="quaternary"
+                              onClick={() => {
+                                // Remove the default charge
+                                handleUpdate('properties', undefined)
+                              }}
+                            />
+                          </Tooltip>
+                        </SummaryRight>
+                      </Summary>
+                    }
+                    data-test="default-charge-accordion-with-group"
+                  >
+                    {children}
+                  </Accordion>
+                )}
+              >
+                <ChargeWrapperSwitch
+                  currency={currency}
+                  formikProps={formikProps}
+                  index={index}
+                  propertyCursor="properties"
+                  premiumWarningDialogRef={premiumWarningDialogRef}
+                  valuePointer={localCharge.properties}
+                  handleUpdate={handleUpdate}
+                />
+              </ConditionalWrapper>
+            )}
+
+            {/* Group properties  */}
+            {localCharge?.groupProperties?.map((group, groupPropertyIndex) => {
+              const associatedFlagGroup = localCharge?.billableMetric?.flatGroups?.find(
+                (flatGroup) => flatGroup.id === group.groupId,
+              )
+
+              const groupKey = associatedFlagGroup?.key
+              const groupName = associatedFlagGroup?.value
+              const hasErrorInGroup =
+                typeof chargeErrors === 'object' &&
+                typeof chargeErrors[index] === 'object' &&
+                // @ts-ignore
+                typeof chargeErrors[index].groupProperties === 'object' &&
+                // @ts-ignore
+                typeof chargeErrors[index].groupProperties[groupPropertyIndex] === 'object' &&
+                // @ts-ignore
+                !!chargeErrors[index].groupProperties[groupPropertyIndex].values
+
+              return (
+                <Accordion
+                  key={`charge-${group.groupId}-group-${group.groupId}`}
+                  noContentMargin
+                  summary={
+                    <Summary>
+                      <SummaryLeft>
+                        <Typography variant="bodyHl" color="grey700">
+                          {localCharge?.groupProperties?.[groupPropertyIndex]
+                            .invoiceDisplayName || (
+                            <>
+                              <span>{groupKey && `${groupKey} • `}</span>
+                              <span>{groupName}</span>
+                            </>
+                          )}
+                        </Typography>
+                        <Tooltip
+                          title={translate('text_65018c8e5c6b626f030bcf8d')}
+                          placement="top-end"
+                        >
+                          <Button
+                            icon="pen"
+                            variant="quaternary"
+                            size="small"
+                            onClick={(e) => {
+                              e.stopPropagation()
+
+                              editInvoiceDisplayNameRef.current?.openDialog({
+                                invoiceDisplayName:
+                                  localCharge?.groupProperties?.[groupPropertyIndex]
+                                    .invoiceDisplayName,
+                                callback: (invoiceDisplayName: string) => {
+                                  formikProps.setFieldValue(
+                                    `charges.${index}.groupProperties.${groupPropertyIndex}.invoiceDisplayName`,
+                                    invoiceDisplayName,
+                                  )
+                                },
+                              })
+                            }}
+                          />
+                        </Tooltip>
+                      </SummaryLeft>
+
+                      <ChargeGroupAccodionSummaryRight>
+                        <Tooltip
+                          placement="top-end"
+                          title={
+                            hasErrorInGroup
+                              ? translate('text_635b975ecea4296eb76924b7')
+                              : translate('text_635b975ecea4296eb76924b1')
+                          }
+                        >
+                          <ValidationIcon
+                            name="validate-filled"
+                            color={hasErrorInGroup ? 'disabled' : 'success'}
+                          />
+                        </Tooltip>
+                        <Tooltip
+                          placement="top-end"
+                          title={translate('text_63aa085d28b8510cd46443ff')}
+                        >
+                          <Button
+                            size="small"
+                            icon="trash"
+                            variant="quaternary"
+                            onClick={() => {
+                              const existingGroupProperties = [
+                                ...(localCharge.groupProperties || []),
+                              ]
+
+                              existingGroupProperties.splice(groupPropertyIndex, 1)
+                              handleUpdate('groupProperties', existingGroupProperties)
+                            }}
+                          />
+                        </Tooltip>
+                      </ChargeGroupAccodionSummaryRight>
+                    </Summary>
+                  }
+                  data-test={`group-charge-accordion-${groupPropertyIndex}`}
+                >
+                  <ChargeWrapperSwitch
+                    currency={currency}
+                    formikProps={formikProps}
+                    index={index}
+                    propertyCursor={`groupProperties.${groupPropertyIndex}.values`}
+                    premiumWarningDialogRef={premiumWarningDialogRef}
+                    valuePointer={
+                      localCharge?.groupProperties &&
+                      localCharge?.groupProperties[groupPropertyIndex].values
+                    }
+                    handleUpdate={handleUpdate}
+                  />
+                </Accordion>
+              )
+            })}
+          </AllChargesWrapper>
+
+          {/* If the charge can have groups */}
+          {!!localCharge.billableMetric.flatGroups?.length && (
+            <>
+              {!!showAddGroup ? (
+                <InlineGroupInputWrapper>
+                  <ComboBox
+                    sortValues={false}
+                    className={SEARCH_CHARGE_GROUP_INPUT_CLASSNAME}
+                    data={[
+                      {
+                        label: translate('text_64e620bca31226337ffc62ad'),
+                        value: DEFAULT_GROUP_VALUE,
+                        disabled: !!localCharge?.properties,
+                      },
+                      ...localCharge.billableMetric.flatGroups?.map((group) => ({
+                        label: `${group.key ? `${group.key} • ` : ''}${group.value}`,
+                        value: group.id,
+                        disabled: localChargeExistingGroupPropertiesIds.includes(group.id),
+                      })),
+                    ]}
+                    placeholder={translate('text_64e6211f8fcca2366dc69005')}
+                    onChange={(newGroupId) => {
+                      if (newGroupId === DEFAULT_GROUP_VALUE) {
+                        handleUpdate('properties', getPropertyShape({}))
+                      } else {
+                        const newGroupProperties = [
+                          ...(localCharge.groupProperties || []),
+                          {
+                            groupId: newGroupId,
+                            value: getPropertyShape({}),
+                          },
+                        ]
+
+                        handleUpdate('groupProperties', newGroupProperties)
+                      }
+                      setShowAddGroup(false)
+                    }}
+                  />
+
+                  <Tooltip placement="top-end" title={translate('text_63aa085d28b8510cd46443ff')}>
+                    <Button
+                      icon="trash"
+                      variant="quaternary"
+                      onClick={() => {
+                        setShowAddGroup(false)
+                      }}
+                    />
+                  </Tooltip>
+                </InlineGroupInputWrapper>
+              ) : (
+                <ChargeAddActionsWrapper data-test="charge-with-group-actions-wrapper">
+                  <ChargeAddActionsWrapperLeft>
+                    <Button
+                      startIcon="plus"
+                      variant="quaternary"
+                      disabled={
+                        (localCharge.groupProperties?.length || 0) ===
+                          (localCharge.billableMetric.flatGroups?.length || 0) &&
+                        !!localCharge.properties
+                      }
+                      onClick={() => {
+                        setShowAddGroup(true)
+                        setTimeout(() => {
+                          ;(
+                            document.querySelector(
+                              `.${SEARCH_CHARGE_GROUP_INPUT_CLASSNAME} .${MUI_INPUT_BASE_ROOT_CLASSNAME}`,
+                            ) as HTMLElement
+                          )?.click()
+                        }, 0)
+                      }}
+                      data-test="add-new-group"
+                    >
+                      {translate('text_64e620bca31226337ffc62b7')}
+                    </Button>
+                    <Button
+                      startIcon="plus"
+                      variant="quaternary"
+                      disabled={
+                        (localCharge.groupProperties?.length || 0) ===
+                        (localCharge.billableMetric.flatGroups?.length || 0)
+                      }
+                      onClick={() => {
+                        const newGroupProperties = [
+                          ...(localCharge.groupProperties || []),
+                          ...(localCharge.billableMetric.flatGroups
+                            ?.filter((g) => !localChargeExistingGroupPropertiesIds.includes(g.id))
+                            .map((group) => ({
+                              groupId: group.id,
+                              values: getPropertyShape({}),
+                            })) || []),
+                        ]
+
+                        handleUpdate('groupProperties', newGroupProperties)
+                      }}
+                      data-test="add-all-group-cta"
+                    >
+                      {translate('text_64e620bca31226337ffc62b9')}
+                    </Button>
+                  </ChargeAddActionsWrapperLeft>
+                  {translate('text_64e620bca31226337ffc62bb', {
+                    count: localCharge.groupProperties?.length || 0,
+                    total: localCharge.billableMetric.flatGroups?.length || 0,
+                  })}
+                </ChargeAddActionsWrapper>
+              )}
+            </>
+          )}
+        </>
+      </Accordion>
+    )
+  },
+)
+
+ChargeGroupChildAccordion.displayName = 'ChargeGroupChildAccordion'
+
+const ChargeModelWrapper = styled.div`
+  padding: ${theme.spacing(4)} ${theme.spacing(4)} 0 ${theme.spacing(4)};
+`
+
+const Title = styled.div`
+  display: flex;
+  flex-direction: column;
+  white-space: pre;
+  min-width: 20px;
+  margin-right: auto;
+`
+
+const ValidationIcon = styled(Icon)`
+  display: flex;
+  align-items: center;
+`
+
+const SummaryLeft = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing(2)};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`
+
+const SummaryRight = styled.div`
+  display: flex;
+  align-items: center;
+  > *:not(:last-child) {
+    margin-right: ${theme.spacing(3)};
+  }
+`
+
+const InlineGroupInputWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing(3)};
+  padding: ${theme.spacing(6)} ${theme.spacing(4)} ${theme.spacing(4)};
+
+  > *:first-child {
+    flex: 1;
+  }
+`
+
+const InlineComboboxLabel = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing(2)};
+`
+
+const Summary = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: ${theme.spacing(3)};
+  overflow: hidden;
+`
+
+const AllChargesWrapper = styled.div<{ $hasGroupDisplay?: boolean; $hasChargesToDisplay: boolean }>`
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing(4)};
+  margin-top: ${({ $hasChargesToDisplay, $hasGroupDisplay }) =>
+    $hasChargesToDisplay && $hasGroupDisplay ? theme.spacing(6) : 0};
+  margin-bottom: ${theme.spacing(6)};
+  padding: ${({ $hasGroupDisplay }) => ($hasGroupDisplay ? `0 ${theme.spacing(4)}` : 0)};
+`
+
+const ChargeAddActionsWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 ${theme.spacing(4)};
+  margin-bottom: ${theme.spacing(4)};
+`
+
+const ChargeAddActionsWrapperLeft = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing(3)};
+`
+
+const ChargeGroupAccodionSummaryRight = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing(3)};
+`
+
+const ChargeSummaryLeftWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`

--- a/src/components/plans/ChargeGroupChildAccordion.tsx
+++ b/src/components/plans/ChargeGroupChildAccordion.tsx
@@ -273,7 +273,6 @@ export const ChargeGroupChildAccordion = memo(
                       e.stopPropagation()
                       e.preventDefault()
 
-                      // TODO: This is not working
                       const deleteCharge = () => {
                         const charges = [...formikProps.values.charges]
 

--- a/src/components/plans/ChargeGroupOptionsAccordion.tsx
+++ b/src/components/plans/ChargeGroupOptionsAccordion.tsx
@@ -1,0 +1,208 @@
+import { gql } from '@apollo/client'
+import { AccordionDetails, AccordionSummary, Accordion as MuiAccordion } from '@mui/material'
+import { TransitionProps } from '@mui/material/transitions'
+import { useState } from 'react'
+import { ReactNode } from 'react'
+import styled from 'styled-components'
+
+import { Button, Chip, Tooltip, Typography } from '~/components/designSystem'
+import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
+import { CurrencyEnum } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { NAV_HEIGHT, theme } from '~/styles'
+
+import { LocalChargeGroupInput } from './types'
+
+gql`
+  fragment ChargeForChargeGroupOptionsAccordion on Charge {
+    id
+    invoiceable
+    minAmountCents
+    payInAdvance
+  }
+`
+
+interface ChargeGroupOptionsAccordionProps {
+  id?: string
+  chargeGroup: LocalChargeGroupInput
+  children: ReactNode | ((args: { isOpen: boolean }) => ReactNode)
+  currency: CurrencyEnum
+  initiallyOpen?: boolean
+  transitionProps?: TransitionProps
+}
+
+export const ChargeGroupOptionsAccordion = ({
+  id,
+  chargeGroup,
+  children,
+  currency,
+  initiallyOpen = false,
+  transitionProps = {},
+}: ChargeGroupOptionsAccordionProps) => {
+  const [isOpen, setIsOpen] = useState(initiallyOpen)
+  const { translate } = useInternationalization()
+
+  return (
+    <Container id={id}>
+      <StyledChargeGroupOptionsAccordion
+        expanded={isOpen}
+        onChange={(_, expanded) => setIsOpen(expanded)}
+        TransitionProps={{ unmountOnExit: true, ...transitionProps }}
+        square
+      >
+        <SummaryWrapper>
+          <Summary>
+            <Typography variant="captionHl" color="grey700">
+              {translate('text_646e2d0cc536351b62ba6f01')}
+            </Typography>
+            <ChipsWrapper>
+              <Chip
+                label={
+                  chargeGroup.payInAdvance
+                    ? translate('text_646e2d0bc536351b62ba6ebb')
+                    : translate('text_646e2d0cc536351b62ba6f0c')
+                }
+              />
+              {/* NOTE: proporated */}
+              <Chip
+                label={
+                  false
+                    ? translate('text_649c47c0a6c1f200de8ff48d')
+                    : translate('text_649c49bcebd91c0082d84446')
+                }
+              />
+              <Chip
+                label={
+                  chargeGroup.invoiceable
+                    ? translate('text_646e2d0cc536351b62ba6f16')
+                    : translate('text_646e2d0cc536351b62ba6fcb')
+                }
+              />
+              <Chip
+                label={
+                  !!Number(chargeGroup.minAmountCents)
+                    ? translate('text_646e2d0cc536351b62ba6fcf', {
+                        minAmountCents: intlFormatNumber(chargeGroup.minAmountCents, {
+                          currencyDisplay: 'symbol',
+                          currency,
+                          maximumFractionDigits: 15,
+                        }),
+                      })
+                    : translate('text_646e2d0cc536351b62ba6f20')
+                }
+              />
+            </ChipsWrapper>
+          </Summary>
+          <Tooltip
+            placement="top-start"
+            title={translate(
+              isOpen ? 'text_624aa732d6af4e0103d40e61' : 'text_624aa79870f60300a3c4d074',
+            )}
+          >
+            <Button
+              tabIndex={-1}
+              data-test="open-charge-group"
+              variant="quaternary"
+              size="small"
+              icon={isOpen ? 'chevron-down' : 'chevron-right'}
+            />
+          </Tooltip>
+        </SummaryWrapper>
+        <Details>{typeof children === 'function' ? children({ isOpen }) : children}</Details>
+      </StyledChargeGroupOptionsAccordion>
+    </Container>
+  )
+}
+
+const Container = styled.div`
+  border-top: 1px solid ${theme.palette.grey[400]};
+  border-radius: 0 0 12px 12px;
+`
+
+const StyledChargeGroupOptionsAccordion = styled(MuiAccordion)`
+  border-radius: 0 0 12px 12px;
+  overflow: hidden;
+
+  &.MuiAccordion-root.MuiPaper-root {
+    border-radius: 0 0 12px 12px;
+    background-color: transparent;
+  }
+  &.MuiAccordion-root {
+    overflow: inherit;
+
+    &:before {
+      height: 0;
+    }
+    &.Mui-expanded {
+      margin: 0;
+    }
+  }
+
+  .MuiAccordionSummary-content {
+    width: 100%;
+  }
+`
+
+const SummaryWrapper = styled(AccordionSummary)`
+  && {
+    min-height: ${NAV_HEIGHT}px;
+    border-radius: 0 0 12px 12px;
+    transition: border-radius 0.025s ease-in-out;
+
+    &.Mui-expanded {
+      border-radius: 0;
+    }
+
+    &.MuiAccordionSummary-root.Mui-focusVisible {
+      background-color: inherit;
+      box-shadow: 0px 0px 0px 4px ${theme.palette.primary[200]};
+      &:hover {
+        background-color: ${theme.palette.grey[100]};
+      }
+    }
+
+    &:hover {
+      background-color: ${theme.palette.grey[100]};
+    }
+
+    &:active {
+      background-color: ${theme.palette.grey[200]};
+    }
+
+    .MuiAccordionSummary-content {
+      display: flex;
+      min-height: ${NAV_HEIGHT}px;
+      box-sizing: border-box;
+      align-items: center;
+      padding: ${theme.spacing(3)} ${theme.spacing(4)};
+    }
+  }
+`
+
+const Summary = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: ${theme.spacing(1)};
+  margin-right: ${theme.spacing(3)};
+`
+
+const ChipsWrapper = styled.div`
+  display: flex;
+  gap: ${theme.spacing(2)};
+  flex-wrap: wrap;
+`
+
+const Details = styled(AccordionDetails)`
+  display: flex;
+  flex-direction: column;
+  box-shadow: ${theme.shadows[5]};
+
+  > *:not(:last-child) {
+    margin-bottom: ${theme.spacing(6)};
+  }
+
+  &.MuiAccordionDetails-root {
+    padding: ${theme.spacing(4)};
+  }
+`

--- a/src/components/plans/ChargeWrapperSwitch.tsx
+++ b/src/components/plans/ChargeWrapperSwitch.tsx
@@ -125,7 +125,6 @@ export const ChargeWrapperSwitch = memo(
         {localCharge.chargeModel === ChargeModelEnum.PackageGroup && (
           <PackageGroupChildCharge
             chargeIndex={index}
-            currency={currency}
             disabled={disabled}
             formikProps={formikProps}
             propertyCursor={propertyCursor}
@@ -140,6 +139,7 @@ export const ChargeWrapperSwitch = memo(
             formikProps={formikProps}
             propertyCursor={propertyCursor}
             valuePointer={valuePointer}
+            isGroupCharge={!!localCharge.chargeGroupId}
           />
         )}
       </MargedWrapper>

--- a/src/components/plans/ChargeWrapperSwitch.tsx
+++ b/src/components/plans/ChargeWrapperSwitch.tsx
@@ -139,7 +139,7 @@ export const ChargeWrapperSwitch = memo(
             formikProps={formikProps}
             propertyCursor={propertyCursor}
             valuePointer={valuePointer}
-            isGroupCharge={!!localCharge.chargeGroupId}
+            isGroupCharge={!!localCharge.chargeGroupId || !!localCharge.chargeGroup}
           />
         )}
       </MargedWrapper>

--- a/src/components/plans/ChargeWrapperSwitch.tsx
+++ b/src/components/plans/ChargeWrapperSwitch.tsx
@@ -19,6 +19,7 @@ import {
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 
 import { GraduatedPercentageChargeTable } from './GraduatedPercentageChargeTable'
+import { PackageGroupChildCharge } from './PackageGroupChildCharge'
 import { PlanFormInput } from './types'
 import { VolumeChargeTable } from './VolumeChargeTable'
 
@@ -113,6 +114,16 @@ export const ChargeWrapperSwitch = memo(
         )}
         {localCharge.chargeModel === ChargeModelEnum.Volume && (
           <VolumeChargeTable
+            chargeIndex={index}
+            currency={currency}
+            disabled={disabled}
+            formikProps={formikProps}
+            propertyCursor={propertyCursor}
+            valuePointer={valuePointer}
+          />
+        )}
+        {localCharge.chargeModel === ChargeModelEnum.PackageGroup && (
+          <PackageGroupChildCharge
             chargeIndex={index}
             currency={currency}
             disabled={disabled}

--- a/src/components/plans/ChargesSection.tsx
+++ b/src/components/plans/ChargesSection.tsx
@@ -692,6 +692,8 @@ export const ChargesSection = memo(
                   )
                   const newChargeIndex = lastMeteredIndex < 0 ? 0 : lastMeteredIndex + 1
 
+                  // NOTE: newGroupId is only used to link charge with charge_group.
+                  //       It will not be used to create objects in database.
                   previousCharges.splice(newChargeIndex, 0, {
                     payInAdvance: true,
                     invoiceable: true,

--- a/src/components/plans/ChargesSection.tsx
+++ b/src/components/plans/ChargesSection.tsx
@@ -103,7 +103,7 @@ export const ChargesSection = memo(
     const { translate } = useInternationalization()
     // NOTE: child charge in group charge is not included in the count
     const hasAnyCharge = useMemo(
-      () => formikProps.values.charges.some((c) => !c.chargeGroupId),
+      () => formikProps.values.charges.some((c) => !c.chargeGroupId && !c.chargeGroup),
       // eslint-disable-next-line react-hooks/exhaustive-deps
       [formikProps.values.charges.length],
     )
@@ -118,7 +118,7 @@ export const ChargesSection = memo(
     const hasAnyMeteredCharge = useMemo(
       () =>
         formikProps.values.charges.some((c) => {
-          return !c.billableMetric.recurring && !c.chargeGroupId
+          return !c.billableMetric.recurring && !c.chargeGroupId && !c.chargeGroup
         }),
       // eslint-disable-next-line react-hooks/exhaustive-deps
       [formikProps.values.charges.length],
@@ -358,7 +358,12 @@ export const ChargesSection = memo(
             <Charges>
               {formikProps.values.charges.map((charge, i) => {
                 // Prevent displaying recurring & group charges
-                if (charge.billableMetric.recurring || !!charge.chargeGroupId) return
+                if (
+                  charge.billableMetric.recurring ||
+                  !!charge.chargeGroupId ||
+                  !!charge.chargeGroup
+                )
+                  return
 
                 const id = getNewChargeId(charge.billableMetric.id, i)
                 const isNew = !alreadyExistingCharges?.find(

--- a/src/components/plans/PackageGroupCharge.tsx
+++ b/src/components/plans/PackageGroupCharge.tsx
@@ -1,0 +1,89 @@
+import { gql } from '@apollo/client'
+import { InputAdornment } from '@mui/material'
+import { FormikProps } from 'formik'
+import { memo, useCallback } from 'react'
+import styled from 'styled-components'
+
+import { getCurrencySymbol } from '~/core/formats/intlFormatNumber'
+import { CurrencyEnum, InputMaybe, PropertiesInput } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { theme } from '~/styles'
+
+import { PlanFormInput } from './types'
+
+import { AmountInput } from '../form/AmountInput/AmountInput'
+
+gql`
+  fragment PackageGroupCharge on Charge {
+    id
+    properties {
+      amount
+      packageSize
+      freeUnits
+    }
+    groupProperties {
+      groupId
+      values {
+        amount
+        packageSize
+        freeUnits
+      }
+    }
+  }
+`
+
+interface PackageGroupChargeProps {
+  chargeGroupIndex: number
+  currency: CurrencyEnum
+  disabled?: boolean
+  formikProps: FormikProps<PlanFormInput>
+  propertyCursor: string
+  valuePointer: InputMaybe<PropertiesInput> | undefined
+}
+
+export const PackageGroupCharge = memo(
+  ({
+    chargeGroupIndex,
+    currency,
+    disabled,
+    formikProps,
+    propertyCursor,
+    valuePointer,
+  }: PackageGroupChargeProps) => {
+    const { translate } = useInternationalization()
+    const handleUpdate = useCallback(
+      (name: string, value: string) => {
+        formikProps.setFieldValue(`chargeGroups.${chargeGroupIndex}.${name}`, value)
+      },
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [chargeGroupIndex],
+    )
+
+    return (
+      <Container>
+        <AmountInput
+          name={`${propertyCursor}.amount`}
+          currency={currency}
+          beforeChangeFormatter={['positiveNumber', 'chargeDecimal']}
+          disabled={disabled}
+          label={translate('text_6282085b4f283b0102655870')}
+          value={valuePointer?.amount || ''}
+          onChange={(value) => handleUpdate(`${propertyCursor}.amount`, value)}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">{getCurrencySymbol(currency)}</InputAdornment>
+            ),
+          }}
+        />
+      </Container>
+    )
+  },
+)
+
+PackageGroupCharge.displayName = 'PackageGroupCharge'
+
+const Container = styled.div`
+  > *:not(:last-child) {
+    margin-bottom: ${theme.spacing(6)};
+  }
+`

--- a/src/components/plans/PackageGroupChildCharge.tsx
+++ b/src/components/plans/PackageGroupChildCharge.tsx
@@ -1,0 +1,130 @@
+import { gql } from '@apollo/client'
+import { InputAdornment } from '@mui/material'
+import { FormikProps } from 'formik'
+import _get from 'lodash/get'
+import { memo, useCallback } from 'react'
+import styled from 'styled-components'
+
+import { Typography } from '~/components/designSystem'
+import { TextInput } from '~/components/form'
+import { getCurrencySymbol } from '~/core/formats/intlFormatNumber'
+import { CurrencyEnum, InputMaybe, PropertiesInput } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { theme } from '~/styles'
+
+import { PlanFormInput } from './types'
+
+import { AmountInput } from '../form/AmountInput/AmountInput'
+
+gql`
+  fragment PackageGroupChildCharge on Charge {
+    id
+    properties {
+      amount
+      packageSize
+      freeUnits
+    }
+    groupProperties {
+      groupId
+      values {
+        amount
+        packageSize
+        freeUnits
+      }
+    }
+  }
+`
+
+interface PackageGroupChildChargeProps {
+  chargeIndex: number
+  currency: CurrencyEnum
+  disabled?: boolean
+  formikProps: FormikProps<PlanFormInput>
+  propertyCursor: string
+  valuePointer: InputMaybe<PropertiesInput> | undefined
+}
+
+export const PackageGroupChildCharge = memo(
+  ({
+    chargeIndex,
+    currency,
+    disabled,
+    formikProps,
+    propertyCursor,
+    valuePointer,
+  }: PackageGroupChildChargeProps) => {
+    const { translate } = useInternationalization()
+    const handleUpdate = useCallback(
+      (name: string, value: string) => {
+        formikProps.setFieldValue(`charges.${chargeIndex}.${name}`, value)
+      },
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [chargeIndex],
+    )
+
+    return (
+      <Container>
+        <AmountInput
+          name={`${propertyCursor}.amount`}
+          currency={currency}
+          beforeChangeFormatter={['positiveNumber', 'chargeDecimal']}
+          disabled={disabled}
+          label={translate('text_6282085b4f283b0102655870')}
+          value={valuePointer?.amount || ''}
+          onChange={(value) => handleUpdate(`${propertyCursor}.amount`, value)}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">{getCurrencySymbol(currency)}</InputAdornment>
+            ),
+          }}
+        />
+        <TextInput
+          name={`${propertyCursor}.packageSize`}
+          beforeChangeFormatter={['positiveNumber', 'int']}
+          error={_get(formikProps.errors, `charges.${chargeIndex}.properties.packageSize`)}
+          disabled={disabled}
+          value={valuePointer?.packageSize as number | undefined}
+          onChange={(value) => handleUpdate(`${propertyCursor}.packageSize`, value)}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <Typography color={disabled ? 'disabled' : 'textSecondary'}>
+                  {translate('text_6282085b4f283b010265587c')}
+                </Typography>
+              </InputAdornment>
+            ),
+            endAdornment: (
+              <InputAdornment position="end">
+                {translate('text_6282085b4f283b0102655884')}
+              </InputAdornment>
+            ),
+          }}
+        />
+        <TextInput
+          name={`${propertyCursor}.freeUnits`}
+          label={translate('text_6282085b4f283b010265588c')}
+          placeholder={translate('text_62824f0e5d93bc008d268d00')}
+          beforeChangeFormatter={['positiveNumber', 'int']}
+          disabled={disabled}
+          value={valuePointer?.freeUnits as number | undefined}
+          onChange={(value) => handleUpdate(`${propertyCursor}.freeUnits`, value)}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                {translate('text_6282085b4f283b0102655894')}
+              </InputAdornment>
+            ),
+          }}
+        />
+      </Container>
+    )
+  },
+)
+
+PackageGroupChildCharge.displayName = 'PackageGroupChildCharge'
+
+const Container = styled.div`
+  > *:not(:last-child) {
+    margin-bottom: ${theme.spacing(6)};
+  }
+`

--- a/src/components/plans/PackageGroupChildCharge.tsx
+++ b/src/components/plans/PackageGroupChildCharge.tsx
@@ -7,14 +7,11 @@ import styled from 'styled-components'
 
 import { Typography } from '~/components/designSystem'
 import { TextInput } from '~/components/form'
-import { getCurrencySymbol } from '~/core/formats/intlFormatNumber'
-import { CurrencyEnum, InputMaybe, PropertiesInput } from '~/generated/graphql'
+import { InputMaybe, PropertiesInput } from '~/generated/graphql'
 import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { theme } from '~/styles'
 
 import { PlanFormInput } from './types'
-
-import { AmountInput } from '../form/AmountInput/AmountInput'
 
 gql`
   fragment PackageGroupChildCharge on Charge {
@@ -37,7 +34,6 @@ gql`
 
 interface PackageGroupChildChargeProps {
   chargeIndex: number
-  currency: CurrencyEnum
   disabled?: boolean
   formikProps: FormikProps<PlanFormInput>
   propertyCursor: string
@@ -47,7 +43,6 @@ interface PackageGroupChildChargeProps {
 export const PackageGroupChildCharge = memo(
   ({
     chargeIndex,
-    currency,
     disabled,
     formikProps,
     propertyCursor,
@@ -64,20 +59,6 @@ export const PackageGroupChildCharge = memo(
 
     return (
       <Container>
-        <AmountInput
-          name={`${propertyCursor}.amount`}
-          currency={currency}
-          beforeChangeFormatter={['positiveNumber', 'chargeDecimal']}
-          disabled={disabled}
-          label={translate('text_6282085b4f283b0102655870')}
-          value={valuePointer?.amount || ''}
-          onChange={(value) => handleUpdate(`${propertyCursor}.amount`, value)}
-          InputProps={{
-            endAdornment: (
-              <InputAdornment position="end">{getCurrencySymbol(currency)}</InputAdornment>
-            ),
-          }}
-        />
         <TextInput
           name={`${propertyCursor}.packageSize`}
           beforeChangeFormatter={['positiveNumber', 'int']}

--- a/src/components/plans/TimebasedCharge.tsx
+++ b/src/components/plans/TimebasedCharge.tsx
@@ -33,6 +33,7 @@ interface TimebasedChargeProps {
   formikProps: FormikProps<PlanFormInput>
   propertyCursor: string
   valuePointer: InputMaybe<PropertiesInput> | undefined
+  isGroupCharge?: boolean
 }
 
 export const TimebasedCharge = memo(
@@ -43,6 +44,7 @@ export const TimebasedCharge = memo(
     formikProps,
     propertyCursor,
     valuePointer,
+    isGroupCharge,
   }: TimebasedChargeProps) => {
     const { translate } = useInternationalization()
     const handleUpdate = useCallback(
@@ -55,20 +57,22 @@ export const TimebasedCharge = memo(
 
     return (
       <Container>
-        <AmountInput
-          name={`${propertyCursor}.amount`}
-          currency={currency}
-          beforeChangeFormatter={['positiveNumber', 'chargeDecimal']}
-          disabled={disabled}
-          label={translate('text_6282085b4f283b0102655870')}
-          value={valuePointer?.amount || ''}
-          onChange={(value) => handleUpdate(`${propertyCursor}.amount`, value)}
-          InputProps={{
-            endAdornment: (
-              <InputAdornment position="end">{getCurrencySymbol(currency)}</InputAdornment>
-            ),
-          }}
-        />
+        {!isGroupCharge && (
+          <AmountInput
+            name={`${propertyCursor}.amount`}
+            currency={currency}
+            beforeChangeFormatter={['positiveNumber', 'chargeDecimal']}
+            disabled={disabled}
+            label={translate('text_6282085b4f283b0102655870')}
+            value={valuePointer?.amount || ''}
+            onChange={(value) => handleUpdate(`${propertyCursor}.amount`, value)}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">{getCurrencySymbol(currency)}</InputAdornment>
+              ),
+            }}
+          />
+        )}
         <TextInput
           name={`${propertyCursor}.blockTimeInMinutes`}
           beforeChangeFormatter={['positiveNumber', 'int']}

--- a/src/components/plans/details/PlanDetailsChargeChildrenGroupSectionAccordion.tsx
+++ b/src/components/plans/details/PlanDetailsChargeChildrenGroupSectionAccordion.tsx
@@ -1,0 +1,110 @@
+import styled from 'styled-components'
+
+import { ConditionalWrapper } from '~/components/ConditionalWrapper'
+import { Accordion, Typography } from '~/components/designSystem'
+import { Charge, CurrencyEnum } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { theme } from '~/styles'
+
+import PlanDetailsChargeWrapperSwitch from './PlanDetailsChargeWrapperSwitch'
+
+interface ChargeWithIndex extends Charge {
+  [index: number]: unknown
+}
+
+type PlanDetailsChargeChildrenGroupSectionAccordionProps = {
+  charge: ChargeWithIndex
+  currency: CurrencyEnum
+}
+
+const PlanDetailsChargeChildrenGroupSectionAccordion = ({
+  charge,
+  currency,
+}: PlanDetailsChargeChildrenGroupSectionAccordionProps) => {
+  const { translate } = useInternationalization()
+
+  return (
+    <Container>
+      <PaddedChargesWrapper>
+        {/* Default properties */}
+        <ConditionalWrapper
+          condition={!!charge.billableMetric.flatGroups?.length}
+          invalidWrapper={(children) => <div>{children}</div>}
+          validWrapper={(children) => (
+            <Accordion
+              summary={
+                <Typography variant="bodyHl" color="grey700">
+                  {translate('text_64e620bca31226337ffc62ad')}
+                </Typography>
+              }
+            >
+              {children}
+            </Accordion>
+          )}
+        >
+          <PlanDetailsChargeSwitchWrapper>
+            <PlanDetailsChargeWrapperSwitch
+              currency={currency}
+              chargeModel={charge.chargeModel}
+              values={charge.properties}
+            />
+          </PlanDetailsChargeSwitchWrapper>
+        </ConditionalWrapper>
+
+        {/* Group properties */}
+        {!!charge?.groupProperties?.length &&
+          charge?.groupProperties?.map((group, i) => {
+            const associatedFlagGroup = charge?.billableMetric?.flatGroups?.find(
+              (flatGroup) => flatGroup.id === group.groupId,
+            )
+
+            const groupKey = associatedFlagGroup?.key
+            const groupName = associatedFlagGroup?.value
+
+            return (
+              <Accordion
+                key={`plan-details-charges-section-accordion-${i}`}
+                summary={
+                  <Typography variant="bodyHl" color="grey700">
+                    {group.invoiceDisplayName || (
+                      <>
+                        <span>{groupKey && `${groupKey} • `}</span>
+                        <span>{groupName}</span>
+                      </>
+                    )}
+                  </Typography>
+                }
+              >
+                <PlanDetailsChargeWrapperSwitch
+                  currency={currency}
+                  chargeModel={charge.chargeModel}
+                  values={group.values}
+                />
+              </Accordion>
+            )
+          })}
+      </PaddedChargesWrapper>
+    </Container>
+  )
+}
+
+export default PlanDetailsChargeChildrenGroupSectionAccordion
+
+const Container = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing(4)};
+`
+
+const PaddedChargesWrapper = styled.div`
+  padding: 0 ${theme.spacing(4)} ${theme.spacing(4)};
+  box-sizing: border-box;
+  box-shadow: ${theme.shadows[7]};
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing(4)};
+`
+
+const PlanDetailsChargeSwitchWrapper = styled.div`
+  padding-top: ${theme.spacing(4)};
+`

--- a/src/components/plans/details/PlanDetailsChargeGroupChildSectionAccordion.tsx
+++ b/src/components/plans/details/PlanDetailsChargeGroupChildSectionAccordion.tsx
@@ -12,15 +12,15 @@ interface ChargeWithIndex extends Charge {
   [index: number]: unknown
 }
 
-type PlanDetailsChargeChildrenGroupSectionAccordionProps = {
+type PlanDetailsChargeGroupChildSectionAccordionProps = {
   charge: ChargeWithIndex
   currency: CurrencyEnum
 }
 
-const PlanDetailsChargeChildrenGroupSectionAccordion = ({
+const PlanDetailsChargeGroupChildSectionAccordion = ({
   charge,
   currency,
-}: PlanDetailsChargeChildrenGroupSectionAccordionProps) => {
+}: PlanDetailsChargeGroupChildSectionAccordionProps) => {
   const { translate } = useInternationalization()
 
   return (
@@ -88,7 +88,7 @@ const PlanDetailsChargeChildrenGroupSectionAccordion = ({
   )
 }
 
-export default PlanDetailsChargeChildrenGroupSectionAccordion
+export default PlanDetailsChargeGroupChildSectionAccordion
 
 const Container = styled.section`
   display: flex;

--- a/src/components/plans/details/PlanDetailsChargeGroupChildSectionAccordion.tsx
+++ b/src/components/plans/details/PlanDetailsChargeGroupChildSectionAccordion.tsx
@@ -47,6 +47,7 @@ const PlanDetailsChargeGroupChildSectionAccordion = ({
               currency={currency}
               chargeModel={charge.chargeModel}
               values={charge.properties}
+              isChildGroup={true}
             />
           </PlanDetailsChargeSwitchWrapper>
         </ConditionalWrapper>

--- a/src/components/plans/details/PlanDetailsChargeGroupSectionAccordion.tsx
+++ b/src/components/plans/details/PlanDetailsChargeGroupSectionAccordion.tsx
@@ -30,8 +30,7 @@ const PlanDetailsChargeGroupSectionAccordion = ({
         <PlanDetailsChargeWrapperSwitch
           currency={currency}
           chargeModel={ChargeModelEnum.PackageGroup}
-          values={chargeGroup.usageChargeGroups?.[0]?.properties ?? []}
-          isGroupPrice={true}
+          groupValues={chargeGroup.properties}
         />
       </PaddedChargesWrapper>
 

--- a/src/components/plans/details/PlanDetailsChargeGroupSectionAccordion.tsx
+++ b/src/components/plans/details/PlanDetailsChargeGroupSectionAccordion.tsx
@@ -8,7 +8,7 @@ import { useInternationalization } from '~/hooks/core/useInternationalization'
 import { theme } from '~/styles'
 import { DetailsInfoGrid, DetailsInfoItem } from '~/styles/detailsPage'
 
-import PlanDetailsChargeChildrenGroupSectionAccordion from './PlanDetailsChargeChildrenGroupSectionAccordion'
+import PlanDetailsChargeGroupChildSectionAccordion from './PlanDetailsChargeGroupChildSectionAccordion'
 import PlanDetailsChargeWrapperSwitch from './PlanDetailsChargeWrapperSwitch'
 
 type PlanDetailsChargeGroupSectionAccordionProps = {
@@ -51,7 +51,7 @@ const PlanDetailsChargeGroupSectionAccordion = ({
             }
           >
             <ChargeSectionWrapper>
-              <PlanDetailsChargeChildrenGroupSectionAccordion
+              <PlanDetailsChargeGroupChildSectionAccordion
                 currency={currency}
                 charge={charge as Charge}
               />

--- a/src/components/plans/details/PlanDetailsChargeGroupSectionAccordion.tsx
+++ b/src/components/plans/details/PlanDetailsChargeGroupSectionAccordion.tsx
@@ -1,0 +1,142 @@
+import styled from 'styled-components'
+
+import { Accordion, Typography } from '~/components/designSystem'
+import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
+import { deserializeAmount } from '~/core/serializers/serializeAmount'
+import { Charge, ChargeGroup, ChargeModelEnum, CurrencyEnum } from '~/generated/graphql'
+import { useInternationalization } from '~/hooks/core/useInternationalization'
+import { theme } from '~/styles'
+import { DetailsInfoGrid, DetailsInfoItem } from '~/styles/detailsPage'
+
+import PlanDetailsChargeChildrenGroupSectionAccordion from './PlanDetailsChargeChildrenGroupSectionAccordion'
+import PlanDetailsChargeWrapperSwitch from './PlanDetailsChargeWrapperSwitch'
+
+type PlanDetailsChargeGroupSectionAccordionProps = {
+  chargesArray: Charge[]
+  chargeGroup: ChargeGroup
+  currency: CurrencyEnum
+}
+
+const PlanDetailsChargeGroupSectionAccordion = ({
+  chargesArray,
+  chargeGroup,
+  currency,
+}: PlanDetailsChargeGroupSectionAccordionProps) => {
+  const { translate } = useInternationalization()
+
+  return (
+    <Container>
+      <PaddedChargesWrapper>
+        <PlanDetailsChargeWrapperSwitch
+          currency={currency}
+          chargeModel={ChargeModelEnum.PackageGroup}
+          values={chargeGroup.usageChargeGroups?.[0]?.properties ?? []}
+          isGroupPrice={true}
+        />
+      </PaddedChargesWrapper>
+
+      <PaddedChargesWrapper>
+        {chargesArray.map((charge, i) => (
+          <Accordion
+            noContentMargin
+            key={`plan-details_charges-section_group-charge-${i}`}
+            summary={
+              <ChargeSummaryWrapper>
+                <Typography variant="bodyHl" color="grey700">
+                  {charge.invoiceDisplayName || charge.billableMetric.name}
+                </Typography>
+                <Typography variant="caption" noWrap>
+                  {charge.billableMetric.code}
+                </Typography>
+              </ChargeSummaryWrapper>
+            }
+          >
+            <ChargeSectionWrapper>
+              <PlanDetailsChargeChildrenGroupSectionAccordion
+                currency={currency}
+                charge={charge as Charge}
+              />
+            </ChargeSectionWrapper>
+          </Accordion>
+        ))}
+      </PaddedChargesWrapper>
+
+      {/* Display options */}
+      <PaddedOptionsWrapper>
+        <DetailsInfoGrid>
+          <DetailsInfoItem
+            label={translate('text_65201b8216455901fe273dd9')}
+            value={
+              chargeGroup?.payInAdvance
+                ? translate('text_646e2d0cc536351b62ba6faa')
+                : translate('text_646e2d0cc536351b62ba6f8c')
+            }
+          />
+          <DetailsInfoItem
+            label={translate('text_65201b8216455901fe273ddb')}
+            value={intlFormatNumber(deserializeAmount(chargeGroup.minAmountCents, currency), {
+              currencyDisplay: 'symbol',
+              currency,
+              maximumFractionDigits: 15,
+            })}
+          />
+          <DetailsInfoItem
+            label={translate('text_65201b8216455901fe273df0')}
+            value={
+              // No proporated on charge group
+              translate('text_65251f4cd55aeb004e5aa5ef')
+            }
+          />
+          <DetailsInfoItem
+            label={translate('text_646e2d0cc536351b62ba6f16')}
+            value={
+              chargeGroup.invoiceable
+                ? translate('text_65251f46339c650084ce0d57')
+                : translate('text_65251f4cd55aeb004e5aa5ef')
+            }
+          />
+          <DetailsInfoItem
+            label={translate('text_645bb193927b375079d28a8f')}
+            value={
+              // No taxes on charge group
+              '-'
+            }
+          />
+        </DetailsInfoGrid>
+      </PaddedOptionsWrapper>
+    </Container>
+  )
+}
+
+export default PlanDetailsChargeGroupSectionAccordion
+
+const Container = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing(4)};
+`
+
+const ChargeSectionWrapper = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing(4)};
+`
+
+const PaddedChargesWrapper = styled.div`
+  padding: 0 ${theme.spacing(4)} ${theme.spacing(4)};
+  box-sizing: border-box;
+  box-shadow: ${theme.shadows[7]};
+  display: flex;
+  flex-direction: column;
+  gap: ${theme.spacing(4)};
+`
+
+const PaddedOptionsWrapper = styled.div`
+  padding: 0 ${theme.spacing(4)} ${theme.spacing(4)};
+  box-sizing: border-box;
+`
+
+const ChargeSummaryWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`

--- a/src/components/plans/details/PlanDetailsChargeWrapperSwitch.tsx
+++ b/src/components/plans/details/PlanDetailsChargeWrapperSwitch.tsx
@@ -20,11 +20,13 @@ const PlanDetailsChargeWrapperSwitch = ({
   chargeModel,
   values,
   groupValues,
+  isChildGroup,
 }: {
   currency: CurrencyEnum
   chargeModel: ChargeModelEnum
   values?: Maybe<Properties> | Maybe<GroupProperties['values']>
   groupValues?: Maybe<ChargeGroupProperties>
+  isChildGroup?: boolean
 }) => {
   const { translate } = useInternationalization()
 
@@ -206,7 +208,8 @@ const PlanDetailsChargeWrapperSwitch = ({
           />
         </ChargeContentWrapper>
       )}
-      {chargeModel === ChargeModelEnum.PackageGroup && !groupValues && (
+      {/* Child group charge */}
+      {chargeModel === ChargeModelEnum.PackageGroup && !!isChildGroup && (
         <ChargeContentWrapper>
           <PlanDetailsChargeTableDisplay
             header={[
@@ -217,7 +220,8 @@ const PlanDetailsChargeWrapperSwitch = ({
           />
         </ChargeContentWrapper>
       )}
-      {chargeModel === ChargeModelEnum.PackageGroup && groupValues && (
+      {/* Parent group charge */}
+      {chargeModel === ChargeModelEnum.PackageGroup && !!groupValues && (
         <ChargeContentWrapper>
           <PlanDetailsChargeTableDisplay
             header={[translate('text_624453d52e945301380e49b6')]}
@@ -233,7 +237,7 @@ const PlanDetailsChargeWrapperSwitch = ({
           />
         </ChargeContentWrapper>
       )}
-      {chargeModel === ChargeModelEnum.Timebased && (
+      {chargeModel === ChargeModelEnum.Timebased && !isChildGroup && (
         <ChargeContentWrapper>
           <PlanDetailsChargeTableDisplay
             header={[translate('text_624453d52e945301380e49b6'), 'Per minutes']}
@@ -247,6 +251,15 @@ const PlanDetailsChargeWrapperSwitch = ({
                 values?.blockTimeInMinutes,
               ],
             ]}
+          />
+        </ChargeContentWrapper>
+      )}
+      {/* Timebased charge inside of a group charge */}
+      {chargeModel === ChargeModelEnum.Timebased && !!isChildGroup && (
+        <ChargeContentWrapper>
+          <PlanDetailsChargeTableDisplay
+            header={['Per minutes']}
+            body={[[values?.blockTimeInMinutes]]}
           />
         </ChargeContentWrapper>
       )}

--- a/src/components/plans/details/PlanDetailsChargeWrapperSwitch.tsx
+++ b/src/components/plans/details/PlanDetailsChargeWrapperSwitch.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import {
-  ChargeGroupsProperties,
+  ChargeGroupProperties,
   ChargeModelEnum,
   CurrencyEnum,
   GroupProperties,
@@ -24,7 +24,7 @@ const PlanDetailsChargeWrapperSwitch = ({
   currency: CurrencyEnum
   chargeModel: ChargeModelEnum
   values?: Maybe<Properties> | Maybe<GroupProperties['values']>
-  groupValues?: Maybe<ChargeGroupsProperties>
+  groupValues?: Maybe<ChargeGroupProperties>
 }) => {
   const { translate } = useInternationalization()
 

--- a/src/components/plans/details/PlanDetailsChargeWrapperSwitch.tsx
+++ b/src/components/plans/details/PlanDetailsChargeWrapperSwitch.tsx
@@ -18,10 +18,12 @@ const PlanDetailsChargeWrapperSwitch = ({
   currency,
   chargeModel,
   values,
+  isGroupPrice,
 }: {
   currency: CurrencyEnum
   chargeModel: ChargeModelEnum
   values?: Maybe<Properties> | Maybe<GroupProperties['values']>
+  isGroupPrice?: boolean
 }) => {
   const { translate } = useInternationalization()
 
@@ -200,6 +202,33 @@ const PlanDetailsChargeWrapperSwitch = ({
                 ]
               })
             })()}
+          />
+        </ChargeContentWrapper>
+      )}
+      {chargeModel === ChargeModelEnum.PackageGroup && !isGroupPrice && (
+        <ChargeContentWrapper>
+          <PlanDetailsChargeTableDisplay
+            header={[
+              translate('text_65201b8216455901fe273de7'),
+              translate('text_65201b8216455901fe273de8'),
+            ]}
+            body={[[values?.packageSize, values?.freeUnits ?? 0]]}
+          />
+        </ChargeContentWrapper>
+      )}
+      {chargeModel === ChargeModelEnum.PackageGroup && isGroupPrice && (
+        <ChargeContentWrapper>
+          <PlanDetailsChargeTableDisplay
+            header={[translate('text_624453d52e945301380e49b6')]}
+            body={[
+              [
+                intlFormatNumber(Number(values?.amount) || 0, {
+                  currency: currency,
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 15,
+                }),
+              ],
+            ]}
           />
         </ChargeContentWrapper>
       )}

--- a/src/components/plans/details/PlanDetailsChargeWrapperSwitch.tsx
+++ b/src/components/plans/details/PlanDetailsChargeWrapperSwitch.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 
 import { intlFormatNumber } from '~/core/formats/intlFormatNumber'
 import {
+  ChargeGroupsProperties,
   ChargeModelEnum,
   CurrencyEnum,
   GroupProperties,
@@ -18,12 +19,12 @@ const PlanDetailsChargeWrapperSwitch = ({
   currency,
   chargeModel,
   values,
-  isGroupPrice,
+  groupValues,
 }: {
   currency: CurrencyEnum
   chargeModel: ChargeModelEnum
   values?: Maybe<Properties> | Maybe<GroupProperties['values']>
-  isGroupPrice?: boolean
+  groupValues?: Maybe<ChargeGroupsProperties>
 }) => {
   const { translate } = useInternationalization()
 
@@ -205,7 +206,7 @@ const PlanDetailsChargeWrapperSwitch = ({
           />
         </ChargeContentWrapper>
       )}
-      {chargeModel === ChargeModelEnum.PackageGroup && !isGroupPrice && (
+      {chargeModel === ChargeModelEnum.PackageGroup && !groupValues && (
         <ChargeContentWrapper>
           <PlanDetailsChargeTableDisplay
             header={[
@@ -216,13 +217,13 @@ const PlanDetailsChargeWrapperSwitch = ({
           />
         </ChargeContentWrapper>
       )}
-      {chargeModel === ChargeModelEnum.PackageGroup && isGroupPrice && (
+      {chargeModel === ChargeModelEnum.PackageGroup && groupValues && (
         <ChargeContentWrapper>
           <PlanDetailsChargeTableDisplay
             header={[translate('text_624453d52e945301380e49b6')]}
             body={[
               [
-                intlFormatNumber(Number(values?.amount) || 0, {
+                intlFormatNumber(Number(groupValues?.amount) || 0, {
                   currency: currency,
                   minimumFractionDigits: 2,
                   maximumFractionDigits: 15,

--- a/src/components/plans/details/PlanDetailsChargesSection.tsx
+++ b/src/components/plans/details/PlanDetailsChargesSection.tsx
@@ -185,7 +185,7 @@ const PlanDetailsChargesSection = ({
               summary={
                 <Typography variant="bodyHl" color="grey700">
                   <ChargeSummaryWrapper>
-                    {chargesArray?.[0]?.chargeGroup?.invoiceDisplayName ??
+                    {chargesArray?.[0]?.chargeGroup?.invoiceDisplayName ||
                       'Group of ' + chargesArray?.[0].billableMetric.name}
                   </ChargeSummaryWrapper>
                 </Typography>

--- a/src/components/plans/details/PlanDetailsChargesSection.tsx
+++ b/src/components/plans/details/PlanDetailsChargesSection.tsx
@@ -40,8 +40,8 @@ const PlanDetailsChargesSection = ({
   const { meteredCharges, recurringCharges, groupChargeMaps } =
     plan?.charges?.reduce(
       (acc, charge) => {
-        if (charge.chargeModel === ChargeModelEnum.PackageGroup) {
-          const groupId = charge.chargeGroup?.id ?? 'default'
+        if (!!charge.chargeGroup) {
+          const groupId = charge.chargeGroup.id
 
           acc.groupChargeMaps.set(groupId, [...(acc.groupChargeMaps.get(groupId) || []), charge])
         } else if (!charge.billableMetric.recurring) {
@@ -178,14 +178,15 @@ const PlanDetailsChargesSection = ({
               {translate('Charges are grouped together and billed as a single line item.')}
             </Typography>
           </div>
-          {Array.from(groupChargeMaps).map(([groupId, chargesArray], groupIndex) => (
+          {Array.from(groupChargeMaps).map(([, chargesArray], groupIndex) => (
             <Accordion
               noContentMargin
               key={`plan-details_charges-section_group-charge-${groupIndex}`}
               summary={
                 <Typography variant="bodyHl" color="grey700">
                   <ChargeSummaryWrapper>
-                    {chargesArray?.[0]?.chargeGroup?.invoiceDisplayName ?? 'Group ' + groupId}
+                    {chargesArray?.[0]?.chargeGroup?.invoiceDisplayName ??
+                      'Group of ' + chargesArray?.[0].billableMetric.name}
                   </ChargeSummaryWrapper>
                 </Typography>
               }

--- a/src/components/plans/types.ts
+++ b/src/components/plans/types.ts
@@ -1,6 +1,7 @@
 import {
   BillableMetricForPlanFragment,
   ChargeGroupInput,
+  ChargeGroupForPlanFragment,
   ChargeInput,
   CreatePlanInput,
   TaxForPlanChargeAccordionFragment,
@@ -9,6 +10,7 @@ import {
 
 export type LocalChargeInput = Omit<ChargeInput, 'billableMetricId'> & {
   billableMetric: BillableMetricForPlanFragment
+  chargeGroup?: ChargeGroupForPlanFragment | null
   id?: string
   // NOTE: this is used for display purpose but will be replaced by taxCodes[] on save
   taxes?: TaxForPlanChargeAccordionFragment[] | null

--- a/src/components/plans/types.ts
+++ b/src/components/plans/types.ts
@@ -1,5 +1,6 @@
 import {
   BillableMetricForPlanFragment,
+  ChargeGroupInput,
   ChargeInput,
   CreatePlanInput,
   TaxForPlanChargeAccordionFragment,
@@ -13,8 +14,15 @@ export type LocalChargeInput = Omit<ChargeInput, 'billableMetricId'> & {
   taxes?: TaxForPlanChargeAccordionFragment[] | null
 }
 
+export type LocalChargeGroupInput = ChargeGroupInput & {
+  id?: string
+  // NOTE: this is used for display purpose but will be replaced by taxCodes[] on save
+  taxes?: TaxForPlanChargeAccordionFragment[] | null
+}
+
 export interface PlanFormInput extends Omit<CreatePlanInput, 'clientMutationId' | 'charges'> {
   charges: LocalChargeInput[]
+  chargeGroups: LocalChargeGroupInput[]
   // NOTE: this is used for display purpose but will be replaced by taxCodes[] on save
   taxes?: TaxForPlanSettingsSectionFragment[]
 }

--- a/src/core/constants/form.ts
+++ b/src/core/constants/form.ts
@@ -18,6 +18,7 @@ export const MUI_BUTTON_BASE_ROOT_CLASSNAME = 'MuiButtonBase-root'
 // Plans
 export const SEARCH_METERED_CHARGE_INPUT_CLASSNAME = 'searchMeteredChargeInput'
 export const SEARCH_RECURRING_CHARGE_INPUT_CLASSNAME = 'searchRecurringChargeInput'
+export const SEARCH_GROUP_CHARGE_INPUT_CLASSNAME = 'searchGroupChargeInput'
 export const SEARCH_TAX_INPUT_FOR_PLAN_CLASSNAME = 'searchTaxForPlanInput'
 export const SEARCH_TAX_INPUT_FOR_CHARGE_CLASSNAME = 'searchTaxForChargeInput'
 export const SEARCH_CHARGE_GROUP_INPUT_CLASSNAME = 'searchChargeGroupInputClassname'

--- a/src/core/serializers/__tests__/serializePlanInput.test.ts
+++ b/src/core/serializers/__tests__/serializePlanInput.test.ts
@@ -70,6 +70,7 @@ describe('serializePlanInput()', () => {
         payInAdvance: true,
         trialPeriod: 1,
         taxCodes: [],
+        chargeGroups: []
       })
 
       expect(plan).toStrictEqual({
@@ -114,6 +115,7 @@ describe('serializePlanInput()', () => {
         payInAdvance: true,
         trialPeriod: 1,
         taxCodes: [],
+        chargeGroups: []
       })
 
       expect(plan).toStrictEqual({
@@ -191,6 +193,7 @@ describe('serializePlanInput()', () => {
         payInAdvance: true,
         trialPeriod: 1,
         taxCodes: [],
+        chargeGroups: []
       })
 
       expect(plan).toStrictEqual({
@@ -268,6 +271,7 @@ describe('serializePlanInput()', () => {
         payInAdvance: true,
         trialPeriod: 1,
         taxCodes: [],
+        chargeGroups: []
       })
 
       expect(plan).toStrictEqual({
@@ -333,6 +337,7 @@ describe('serializePlanInput()', () => {
         payInAdvance: true,
         trialPeriod: 1,
         taxCodes: [],
+        chargeGroups: []
       })
 
       expect(plan).toStrictEqual({
@@ -398,6 +403,7 @@ describe('serializePlanInput()', () => {
         payInAdvance: true,
         trialPeriod: 1,
         taxCodes: [],
+        chargeGroups: []
       })
 
       expect(plan).toStrictEqual({
@@ -463,6 +469,7 @@ describe('serializePlanInput()', () => {
         payInAdvance: true,
         trialPeriod: 1,
         taxCodes: [],
+        chargeGroups: []
       })
 
       expect(plan).toStrictEqual({

--- a/src/core/serializers/getChargeGroupPropertyShape.ts
+++ b/src/core/serializers/getChargeGroupPropertyShape.ts
@@ -1,0 +1,10 @@
+import { ChargeGroupPropertiesInput } from '~/generated/graphql'
+
+const getChargeGroupPropertyShape = (properties: ChargeGroupPropertiesInput | undefined) => {
+  return {
+    amount: properties?.amount || undefined,
+    freeUnits: properties?.freeUnits || 0,
+  }
+}
+
+export default getChargeGroupPropertyShape

--- a/src/core/serializers/getPropertyShape.ts
+++ b/src/core/serializers/getPropertyShape.ts
@@ -17,6 +17,7 @@ const getPropertyShape = (properties: PropertiesInput | undefined) => {
     graduatedPercentageRanges: properties?.graduatedPercentageRanges || undefined,
     volumeRanges: properties?.volumeRanges || undefined,
     rate: properties?.rate || undefined,
+    blockTimeInMinutes: properties?.blockTimeInMinutes || undefined,
   }
 }
 

--- a/src/core/serializers/serializePlanInput.ts
+++ b/src/core/serializers/serializePlanInput.ts
@@ -60,7 +60,7 @@ const serializeProperties = (properties: Properties, chargeModel: ChargeModelEnu
             : undefined,
         }
       : { volumeRanges: undefined }),
-    ...(chargeModel === ChargeModelEnum.Package
+    ...(chargeModel === ChargeModelEnum.Package || chargeModel === ChargeModelEnum.PackageGroup
       ? { freeUnits: properties?.freeUnits || 0 }
       : { packageSize: undefined, freeUnits: undefined }),
     ...(chargeModel === ChargeModelEnum.Percentage

--- a/src/core/serializers/serializePlanInput.ts
+++ b/src/core/serializers/serializePlanInput.ts
@@ -98,6 +98,7 @@ export const serializePlanInput = (values: PlanFormInput) => {
         groupProperties,
         minAmountCents,
         taxes: chargeTaxes,
+        chargeGroup,
         ...charge
       }) => {
         return {
@@ -119,6 +120,7 @@ export const serializePlanInput = (values: PlanFormInput) => {
                 },
               }))
             : [],
+          chargeGroupId: chargeGroup?.id,
           ...charge,
         }
       },

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -191,6 +191,7 @@ export enum BillingTimeEnum {
 export type Charge = {
   __typename?: 'Charge';
   billableMetric: BillableMetric;
+  chargeGroup?: Maybe<ChargeGroup>;
   chargeModel: ChargeModelEnum;
   createdAt: Scalars['ISO8601DateTime']['output'];
   deletedAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -204,6 +205,20 @@ export type Charge = {
   prorated: Scalars['Boolean']['output'];
   taxes?: Maybe<Array<Tax>>;
   updatedAt: Scalars['ISO8601DateTime']['output'];
+};
+
+export type ChargeGroup = {
+  __typename?: 'ChargeGroup';
+  charges?: Maybe<Array<Charge>>;
+  createdAt: Scalars['ISO8601DateTime']['output'];
+  deletedAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
+  id: Scalars['ID']['output'];
+  invoiceDisplayName?: Maybe<Scalars['String']['output']>;
+  invoiceable: Scalars['Boolean']['output'];
+  minAmountCents: Scalars['BigInt']['output'];
+  payInAdvance: Scalars['Boolean']['output'];
+  updatedAt: Scalars['ISO8601DateTime']['output'];
+  usageChargeGroups?: Maybe<Array<UsageChargeGroup>>;
 };
 
 export type ChargeInput = {
@@ -224,6 +239,7 @@ export enum ChargeModelEnum {
   Graduated = 'graduated',
   GraduatedPercentage = 'graduated_percentage',
   Package = 'package',
+  PackageGroup = 'package_group',
   Percentage = 'percentage',
   Standard = 'standard',
   Timebased = 'timebased',
@@ -3847,6 +3863,25 @@ export type UpdateSubscriptionInput = {
   subscriptionAt?: InputMaybe<Scalars['ISO8601DateTime']['input']>;
 };
 
+export type UsageChargeGroup = {
+  __typename?: 'UsageChargeGroup';
+  availableGroupUsage?: Maybe<Scalars['JSON']['output']>;
+  chargeGroup: ChargeGroup;
+  createdAt: Scalars['ISO8601DateTime']['output'];
+  currentPackageCount: Scalars['BigInt']['output'];
+  deletedAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
+  id: Scalars['ID']['output'];
+  properties: UsageChargeGroupsProperties;
+  subscription: Subscription;
+  updatedAt: Scalars['ISO8601DateTime']['output'];
+};
+
+export type UsageChargeGroupsProperties = {
+  __typename?: 'UsageChargeGroupsProperties';
+  amount?: Maybe<Scalars['String']['output']>;
+  freeUnits?: Maybe<Scalars['BigInt']['output']>;
+};
+
 export type User = {
   __typename?: 'User';
   createdAt: Scalars['ISO8601DateTime']['output'];
@@ -4541,6 +4576,8 @@ export type GraduatedPercentageChargeFragment = { __typename?: 'Charge', id: str
 
 export type PackageChargeFragment = { __typename?: 'Charge', id: string, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null } }> | null };
 
+export type PackageGroupChargeFragment = { __typename?: 'Charge', id: string, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null } }> | null };
+
 export type PlanItemFragment = { __typename?: 'Plan', id: string, name: string, code: string, chargesCount: number, activeSubscriptionsCount: number, createdAt: any, draftInvoicesCount: number };
 
 export type TaxForPlanSettingsSectionFragment = { __typename?: 'Tax', id: string, code: string, name: string, rate: number };
@@ -4564,7 +4601,7 @@ export type GetPlanForDetailsOverviewSectionQueryVariables = Exact<{
 }>;
 
 
-export type GetPlanForDetailsOverviewSectionQuery = { __typename?: 'Query', plan?: { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, payInAdvance: boolean, invoiceDisplayName?: string | null, amountCents: any, amountCurrency: CurrencyEnum, trialPeriod?: number | null, subscriptionsCount: number, billChargesMonthly?: boolean | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, charges?: Array<{ __typename?: 'Charge', id: string, minAmountCents: any, payInAdvance: boolean, chargeModel: ChargeModelEnum, invoiceable: boolean, prorated: boolean, invoiceDisplayName?: string | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, code: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, blockTimeInMinutes?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } }> | null }> | null } | null };
+export type GetPlanForDetailsOverviewSectionQuery = { __typename?: 'Query', plan?: { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, payInAdvance: boolean, invoiceDisplayName?: string | null, amountCents: any, amountCurrency: CurrencyEnum, trialPeriod?: number | null, subscriptionsCount: number, billChargesMonthly?: boolean | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, charges?: Array<{ __typename?: 'Charge', id: string, minAmountCents: any, payInAdvance: boolean, chargeModel: ChargeModelEnum, invoiceable: boolean, prorated: boolean, invoiceDisplayName?: string | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, code: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, chargeGroup?: { __typename?: 'ChargeGroup', id: string, invoiceDisplayName?: string | null, minAmountCents: any, payInAdvance: boolean, invoiceable: boolean, usageChargeGroups?: Array<{ __typename?: 'UsageChargeGroup', id: string, properties: { __typename?: 'UsageChargeGroupsProperties', amount?: string | null } }> | null } | null, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, blockTimeInMinutes?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } }> | null }> | null } | null };
 
 export type GetSubscribtionsForPlanDetailsQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
@@ -4876,7 +4913,7 @@ export type GetSinglePlanQueryVariables = Exact<{
 }>;
 
 
-export type GetSinglePlanQuery = { __typename?: 'Query', plan?: { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, payInAdvance: boolean, invoiceDisplayName?: string | null, amountCents: any, amountCurrency: CurrencyEnum, trialPeriod?: number | null, subscriptionsCount: number, billChargesMonthly?: boolean | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, charges?: Array<{ __typename?: 'Charge', id: string, minAmountCents: any, payInAdvance: boolean, chargeModel: ChargeModelEnum, invoiceable: boolean, prorated: boolean, invoiceDisplayName?: string | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, code: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, blockTimeInMinutes?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } }> | null }> | null } | null };
+export type GetSinglePlanQuery = { __typename?: 'Query', plan?: { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, payInAdvance: boolean, invoiceDisplayName?: string | null, amountCents: any, amountCurrency: CurrencyEnum, trialPeriod?: number | null, subscriptionsCount: number, billChargesMonthly?: boolean | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, charges?: Array<{ __typename?: 'Charge', id: string, minAmountCents: any, payInAdvance: boolean, chargeModel: ChargeModelEnum, invoiceable: boolean, prorated: boolean, invoiceDisplayName?: string | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, code: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, chargeGroup?: { __typename?: 'ChargeGroup', id: string, invoiceDisplayName?: string | null, minAmountCents: any, payInAdvance: boolean, invoiceable: boolean, usageChargeGroups?: Array<{ __typename?: 'UsageChargeGroup', id: string, properties: { __typename?: 'UsageChargeGroupsProperties', amount?: string | null } }> | null } | null, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, blockTimeInMinutes?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } }> | null }> | null } | null };
 
 export type CreatePlanMutationVariables = Exact<{
   input: CreatePlanInput;
@@ -5142,7 +5179,7 @@ export type TaxForPlanAndChargesInPlanFormFragment = { __typename?: 'Tax', id: s
 
 export type BillableMetricForPlanFragment = { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null };
 
-export type EditPlanFragment = { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, payInAdvance: boolean, invoiceDisplayName?: string | null, amountCents: any, amountCurrency: CurrencyEnum, trialPeriod?: number | null, subscriptionsCount: number, billChargesMonthly?: boolean | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, charges?: Array<{ __typename?: 'Charge', id: string, minAmountCents: any, payInAdvance: boolean, chargeModel: ChargeModelEnum, invoiceable: boolean, prorated: boolean, invoiceDisplayName?: string | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, code: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, blockTimeInMinutes?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } }> | null }> | null };
+export type EditPlanFragment = { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, payInAdvance: boolean, invoiceDisplayName?: string | null, amountCents: any, amountCurrency: CurrencyEnum, trialPeriod?: number | null, subscriptionsCount: number, billChargesMonthly?: boolean | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, charges?: Array<{ __typename?: 'Charge', id: string, minAmountCents: any, payInAdvance: boolean, chargeModel: ChargeModelEnum, invoiceable: boolean, prorated: boolean, invoiceDisplayName?: string | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, code: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, chargeGroup?: { __typename?: 'ChargeGroup', id: string, invoiceDisplayName?: string | null, minAmountCents: any, payInAdvance: boolean, invoiceable: boolean, usageChargeGroups?: Array<{ __typename?: 'UsageChargeGroup', id: string, properties: { __typename?: 'UsageChargeGroupsProperties', amount?: string | null } }> | null } | null, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, blockTimeInMinutes?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } }> | null }> | null };
 
 export type AddSubscriptionPlanFragment = { __typename?: 'Plan', id: string, name: string, code: string, interval: PlanInterval };
 
@@ -6955,6 +6992,24 @@ export const ChargeForChargeOptionsAccordionFragmentDoc = gql`
   payInAdvance
 }
     `;
+export const PackageGroupChargeFragmentDoc = gql`
+    fragment PackageGroupCharge on Charge {
+  id
+  properties {
+    amount
+    packageSize
+    freeUnits
+  }
+  groupProperties {
+    groupId
+    values {
+      amount
+      packageSize
+      freeUnits
+    }
+  }
+}
+    `;
 export const TimebasedChargeFragmentDoc = gql`
     fragment TimebasedCharge on Charge {
   id
@@ -7003,6 +7058,7 @@ export const ChargeAccordionFragmentDoc = gql`
   ...PackageCharge
   ...PercentageCharge
   ...ChargeForChargeOptionsAccordion
+  ...PackageGroupCharge
   ...TimebasedCharge
 }
     ${TaxForPlanChargeAccordionFragmentDoc}
@@ -7012,6 +7068,7 @@ ${VolumeRangesFragmentDoc}
 ${PackageChargeFragmentDoc}
 ${PercentageChargeFragmentDoc}
 ${ChargeForChargeOptionsAccordionFragmentDoc}
+${PackageGroupChargeFragmentDoc}
 ${TimebasedChargeFragmentDoc}`;
 export const PlanForChargeAccordionFragmentDoc = gql`
     fragment PlanForChargeAccordion on Plan {
@@ -7079,6 +7136,19 @@ export const EditPlanFragmentDoc = gql`
     }
     ...ChargeAccordion
     chargeModel
+    chargeGroup {
+      id
+      invoiceDisplayName
+      minAmountCents
+      payInAdvance
+      invoiceable
+      usageChargeGroups {
+        id
+        properties {
+          amount
+        }
+      }
+    }
   }
   ...PlanForChargeAccordion
   ...PlanForSettingsSection

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -3848,6 +3848,7 @@ export type UpdatePlanInput = {
   amountCents: Scalars['BigInt']['input'];
   amountCurrency: CurrencyEnum;
   billChargesMonthly?: InputMaybe<Scalars['Boolean']['input']>;
+  chargeGroups?: InputMaybe<Array<ChargeGroupInput>>;
   charges: Array<ChargeInput>;
   /** A unique identifier for the client performing the mutation. */
   clientMutationId?: InputMaybe<Scalars['String']['input']>;

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -217,19 +217,34 @@ export type ChargeGroup = {
   invoiceable: Scalars['Boolean']['output'];
   minAmountCents: Scalars['BigInt']['output'];
   payInAdvance: Scalars['Boolean']['output'];
-  properties: ChargeGroupsProperties;
+  properties: ChargeGroupProperties;
   updatedAt: Scalars['ISO8601DateTime']['output'];
   usageChargeGroups?: Maybe<Array<UsageChargeGroup>>;
 };
 
-export type ChargeGroupsProperties = {
-  __typename?: 'ChargeGroupsProperties';
+export type ChargeGroupInput = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  invoiceDisplayName?: InputMaybe<Scalars['String']['input']>;
+  invoiceable?: InputMaybe<Scalars['Boolean']['input']>;
+  minAmountCents?: InputMaybe<Scalars['BigInt']['input']>;
+  payInAdvance?: InputMaybe<Scalars['Boolean']['input']>;
+  properties?: InputMaybe<ChargeGroupPropertiesInput>;
+};
+
+export type ChargeGroupProperties = {
+  __typename?: 'ChargeGroupProperties';
   amount?: Maybe<Scalars['String']['output']>;
   freeUnits?: Maybe<Scalars['BigInt']['output']>;
 };
 
+export type ChargeGroupPropertiesInput = {
+  amount?: InputMaybe<Scalars['String']['input']>;
+  freeUnits?: InputMaybe<Scalars['BigInt']['input']>;
+};
+
 export type ChargeInput = {
   billableMetricId: Scalars['ID']['input'];
+  chargeGroupId?: InputMaybe<Scalars['ID']['input']>;
   chargeModel: ChargeModelEnum;
   groupProperties?: InputMaybe<Array<GroupPropertiesInput>>;
   id?: InputMaybe<Scalars['ID']['input']>;
@@ -1009,6 +1024,7 @@ export type CreatePlanInput = {
   amountCents: Scalars['BigInt']['input'];
   amountCurrency: CurrencyEnum;
   billChargesMonthly?: InputMaybe<Scalars['Boolean']['input']>;
+  chargeGroups?: InputMaybe<Array<ChargeGroupInput>>;
   charges: Array<ChargeInput>;
   /** A unique identifier for the client performing the mutation. */
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
@@ -2713,6 +2729,9 @@ export type Plan = {
   amountCents: Scalars['BigInt']['output'];
   amountCurrency: CurrencyEnum;
   billChargesMonthly?: Maybe<Scalars['Boolean']['output']>;
+  chargeGroups?: Maybe<Array<ChargeGroup>>;
+  /** Number of charge groups attached to a plan */
+  chargeGroupsCount: Scalars['Int']['output'];
   charges?: Maybe<Array<Charge>>;
   /** Number of charges attached to a plan */
   chargesCount: Scalars['Int']['output'];
@@ -4533,9 +4552,11 @@ export type GetTaxesForChargesQueryVariables = Exact<{
 
 export type GetTaxesForChargesQuery = { __typename?: 'Query', taxes: { __typename?: 'TaxCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> } };
 
-export type ChargeGroupAccordionFragment = { __typename?: 'ChargeGroup', id: string, invoiceable: boolean, minAmountCents: any, payInAdvance: boolean, invoiceDisplayName?: string | null, properties: { __typename?: 'ChargeGroupsProperties', amount?: string | null }, charges?: Array<{ __typename?: 'Charge', id: string, chargeModel: ChargeModelEnum, invoiceable: boolean, minAmountCents: any, payInAdvance: boolean, prorated: boolean, invoiceDisplayName?: string | null, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, blockTimeInMinutes?: any | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null } }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null }> | null };
+export type ChargeGroupAccordionFragment = { __typename?: 'ChargeGroup', id: string, invoiceDisplayName?: string | null, invoiceable: boolean, minAmountCents: any, payInAdvance: boolean, properties: { __typename?: 'ChargeGroupProperties', amount?: string | null }, charges?: Array<{ __typename?: 'Charge', id: string, chargeModel: ChargeModelEnum, invoiceable: boolean, minAmountCents: any, payInAdvance: boolean, prorated: boolean, invoiceDisplayName?: string | null, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, blockTimeInMinutes?: any | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null } }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null }> | null };
 
 export type ChargeGroupChildAccordionFragment = { __typename?: 'Charge', id: string, chargeModel: ChargeModelEnum, invoiceable: boolean, minAmountCents: any, payInAdvance: boolean, prorated: boolean, invoiceDisplayName?: string | null, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, blockTimeInMinutes?: any | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null } }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null };
+
+export type ChargeForChargeGroupOptionsAccordionFragment = { __typename?: 'Charge', id: string, invoiceable: boolean, minAmountCents: any, payInAdvance: boolean };
 
 export type ChargeForChargeOptionsAccordionFragment = { __typename?: 'Charge', id: string, invoiceable: boolean, minAmountCents: any, payInAdvance: boolean };
 
@@ -4582,6 +4603,8 @@ export type PackageChargeFragment = { __typename?: 'Charge', id: string, propert
 
 export type PackageGroupChargeFragment = { __typename?: 'Charge', id: string, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null } }> | null };
 
+export type PackageGroupChildChargeFragment = { __typename?: 'Charge', id: string, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null } }> | null };
+
 export type PlanItemFragment = { __typename?: 'Plan', id: string, name: string, code: string, chargesCount: number, activeSubscriptionsCount: number, createdAt: any, draftInvoicesCount: number };
 
 export type TaxForPlanSettingsSectionFragment = { __typename?: 'Tax', id: string, code: string, name: string, rate: number };
@@ -4605,7 +4628,7 @@ export type GetPlanForDetailsOverviewSectionQueryVariables = Exact<{
 }>;
 
 
-export type GetPlanForDetailsOverviewSectionQuery = { __typename?: 'Query', plan?: { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, payInAdvance: boolean, invoiceDisplayName?: string | null, amountCents: any, amountCurrency: CurrencyEnum, trialPeriod?: number | null, subscriptionsCount: number, billChargesMonthly?: boolean | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, charges?: Array<{ __typename?: 'Charge', id: string, minAmountCents: any, payInAdvance: boolean, chargeModel: ChargeModelEnum, invoiceable: boolean, prorated: boolean, invoiceDisplayName?: string | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, code: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, chargeGroup?: { __typename?: 'ChargeGroup', id: string, invoiceDisplayName?: string | null, minAmountCents: any, payInAdvance: boolean, invoiceable: boolean, properties: { __typename?: 'ChargeGroupsProperties', amount?: string | null } } | null, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, blockTimeInMinutes?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } }> | null }> | null } | null };
+export type GetPlanForDetailsOverviewSectionQuery = { __typename?: 'Query', plan?: { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, payInAdvance: boolean, invoiceDisplayName?: string | null, amountCents: any, amountCurrency: CurrencyEnum, trialPeriod?: number | null, subscriptionsCount: number, billChargesMonthly?: boolean | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, charges?: Array<{ __typename?: 'Charge', id: string, minAmountCents: any, payInAdvance: boolean, chargeModel: ChargeModelEnum, invoiceable: boolean, prorated: boolean, invoiceDisplayName?: string | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, code: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, chargeGroup?: { __typename?: 'ChargeGroup', id: string, invoiceDisplayName?: string | null, minAmountCents: any, payInAdvance: boolean, invoiceable: boolean, properties: { __typename?: 'ChargeGroupProperties', amount?: string | null } } | null, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, blockTimeInMinutes?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } }> | null }> | null, chargeGroups?: Array<{ __typename?: 'ChargeGroup', id: string, invoiceDisplayName?: string | null, minAmountCents: any, payInAdvance: boolean, invoiceable: boolean, properties: { __typename?: 'ChargeGroupProperties', amount?: string | null } }> | null } | null };
 
 export type GetSubscribtionsForPlanDetailsQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
@@ -4917,7 +4940,7 @@ export type GetSinglePlanQueryVariables = Exact<{
 }>;
 
 
-export type GetSinglePlanQuery = { __typename?: 'Query', plan?: { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, payInAdvance: boolean, invoiceDisplayName?: string | null, amountCents: any, amountCurrency: CurrencyEnum, trialPeriod?: number | null, subscriptionsCount: number, billChargesMonthly?: boolean | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, charges?: Array<{ __typename?: 'Charge', id: string, minAmountCents: any, payInAdvance: boolean, chargeModel: ChargeModelEnum, invoiceable: boolean, prorated: boolean, invoiceDisplayName?: string | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, code: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, chargeGroup?: { __typename?: 'ChargeGroup', id: string, invoiceDisplayName?: string | null, minAmountCents: any, payInAdvance: boolean, invoiceable: boolean, properties: { __typename?: 'ChargeGroupsProperties', amount?: string | null } } | null, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, blockTimeInMinutes?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } }> | null }> | null } | null };
+export type GetSinglePlanQuery = { __typename?: 'Query', plan?: { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, payInAdvance: boolean, invoiceDisplayName?: string | null, amountCents: any, amountCurrency: CurrencyEnum, trialPeriod?: number | null, subscriptionsCount: number, billChargesMonthly?: boolean | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, charges?: Array<{ __typename?: 'Charge', id: string, minAmountCents: any, payInAdvance: boolean, chargeModel: ChargeModelEnum, invoiceable: boolean, prorated: boolean, invoiceDisplayName?: string | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, code: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, chargeGroup?: { __typename?: 'ChargeGroup', id: string, invoiceDisplayName?: string | null, minAmountCents: any, payInAdvance: boolean, invoiceable: boolean, properties: { __typename?: 'ChargeGroupProperties', amount?: string | null } } | null, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, blockTimeInMinutes?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } }> | null }> | null, chargeGroups?: Array<{ __typename?: 'ChargeGroup', id: string, invoiceDisplayName?: string | null, minAmountCents: any, payInAdvance: boolean, invoiceable: boolean, properties: { __typename?: 'ChargeGroupProperties', amount?: string | null } }> | null } | null };
 
 export type CreatePlanMutationVariables = Exact<{
   input: CreatePlanInput;
@@ -5183,7 +5206,7 @@ export type TaxForPlanAndChargesInPlanFormFragment = { __typename?: 'Tax', id: s
 
 export type BillableMetricForPlanFragment = { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null };
 
-export type EditPlanFragment = { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, payInAdvance: boolean, invoiceDisplayName?: string | null, amountCents: any, amountCurrency: CurrencyEnum, trialPeriod?: number | null, subscriptionsCount: number, billChargesMonthly?: boolean | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, charges?: Array<{ __typename?: 'Charge', id: string, minAmountCents: any, payInAdvance: boolean, chargeModel: ChargeModelEnum, invoiceable: boolean, prorated: boolean, invoiceDisplayName?: string | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, code: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, chargeGroup?: { __typename?: 'ChargeGroup', id: string, invoiceDisplayName?: string | null, minAmountCents: any, payInAdvance: boolean, invoiceable: boolean, properties: { __typename?: 'ChargeGroupsProperties', amount?: string | null } } | null, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, blockTimeInMinutes?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } }> | null }> | null };
+export type EditPlanFragment = { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, payInAdvance: boolean, invoiceDisplayName?: string | null, amountCents: any, amountCurrency: CurrencyEnum, trialPeriod?: number | null, subscriptionsCount: number, billChargesMonthly?: boolean | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, charges?: Array<{ __typename?: 'Charge', id: string, minAmountCents: any, payInAdvance: boolean, chargeModel: ChargeModelEnum, invoiceable: boolean, prorated: boolean, invoiceDisplayName?: string | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, code: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, chargeGroup?: { __typename?: 'ChargeGroup', id: string, invoiceDisplayName?: string | null, minAmountCents: any, payInAdvance: boolean, invoiceable: boolean, properties: { __typename?: 'ChargeGroupProperties', amount?: string | null } } | null, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, blockTimeInMinutes?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } }> | null }> | null, chargeGroups?: Array<{ __typename?: 'ChargeGroup', id: string, invoiceDisplayName?: string | null, minAmountCents: any, payInAdvance: boolean, invoiceable: boolean, properties: { __typename?: 'ChargeGroupProperties', amount?: string | null } }> | null };
 
 export type AddSubscriptionPlanFragment = { __typename?: 'Plan', id: string, name: string, code: string, interval: PlanInterval };
 
@@ -5979,8 +6002,8 @@ export const TaxForPlanChargeAccordionFragmentDoc = gql`
   rate
 }
     `;
-export const ChargeForChargeOptionsAccordionFragmentDoc = gql`
-    fragment ChargeForChargeOptionsAccordion on Charge {
+export const ChargeForChargeGroupOptionsAccordionFragmentDoc = gql`
+    fragment ChargeForChargeGroupOptionsAccordion on Charge {
   id
   invoiceable
   minAmountCents
@@ -6047,21 +6070,21 @@ export const ChargeGroupChildAccordionFragmentDoc = gql`
   taxes {
     ...TaxForPlanChargeAccordion
   }
-  ...ChargeForChargeOptionsAccordion
+  ...ChargeForChargeGroupOptionsAccordion
   ...PackageGroupCharge
   ...TimebasedCharge
 }
     ${TaxForPlanChargeAccordionFragmentDoc}
-${ChargeForChargeOptionsAccordionFragmentDoc}
+${ChargeForChargeGroupOptionsAccordionFragmentDoc}
 ${PackageGroupChargeFragmentDoc}
 ${TimebasedChargeFragmentDoc}`;
 export const ChargeGroupAccordionFragmentDoc = gql`
     fragment ChargeGroupAccordion on ChargeGroup {
   id
+  invoiceDisplayName
   invoiceable
   minAmountCents
   payInAdvance
-  invoiceDisplayName
   properties {
     amount
   }
@@ -6081,6 +6104,24 @@ export const BillableMetricForChargeSectionFragmentDoc = gql`
     id
     key
     value
+  }
+}
+    `;
+export const PackageGroupChildChargeFragmentDoc = gql`
+    fragment PackageGroupChildCharge on Charge {
+  id
+  properties {
+    amount
+    packageSize
+    freeUnits
+  }
+  groupProperties {
+    groupId
+    values {
+      amount
+      packageSize
+      freeUnits
+    }
   }
 }
     `;
@@ -7079,6 +7120,14 @@ export const PercentageChargeFragmentDoc = gql`
   }
 }
     `;
+export const ChargeForChargeOptionsAccordionFragmentDoc = gql`
+    fragment ChargeForChargeOptionsAccordion on Charge {
+  id
+  invoiceable
+  minAmountCents
+  payInAdvance
+}
+    `;
 export const ChargeAccordionFragmentDoc = gql`
     fragment ChargeAccordion on Charge {
   id
@@ -7203,6 +7252,16 @@ export const EditPlanFragmentDoc = gql`
       properties {
         amount
       }
+    }
+  }
+  chargeGroups {
+    id
+    invoiceDisplayName
+    minAmountCents
+    payInAdvance
+    invoiceable
+    properties {
+      amount
     }
   }
   ...PlanForChargeAccordion

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -217,8 +217,15 @@ export type ChargeGroup = {
   invoiceable: Scalars['Boolean']['output'];
   minAmountCents: Scalars['BigInt']['output'];
   payInAdvance: Scalars['Boolean']['output'];
+  properties: ChargeGroupsProperties;
   updatedAt: Scalars['ISO8601DateTime']['output'];
   usageChargeGroups?: Maybe<Array<UsageChargeGroup>>;
+};
+
+export type ChargeGroupsProperties = {
+  __typename?: 'ChargeGroupsProperties';
+  amount?: Maybe<Scalars['String']['output']>;
+  freeUnits?: Maybe<Scalars['BigInt']['output']>;
 };
 
 export type ChargeInput = {
@@ -3871,15 +3878,8 @@ export type UsageChargeGroup = {
   currentPackageCount: Scalars['BigInt']['output'];
   deletedAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
   id: Scalars['ID']['output'];
-  properties: UsageChargeGroupsProperties;
   subscription: Subscription;
   updatedAt: Scalars['ISO8601DateTime']['output'];
-};
-
-export type UsageChargeGroupsProperties = {
-  __typename?: 'UsageChargeGroupsProperties';
-  amount?: Maybe<Scalars['String']['output']>;
-  freeUnits?: Maybe<Scalars['BigInt']['output']>;
 };
 
 export type User = {
@@ -4533,6 +4533,10 @@ export type GetTaxesForChargesQueryVariables = Exact<{
 
 export type GetTaxesForChargesQuery = { __typename?: 'Query', taxes: { __typename?: 'TaxCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> } };
 
+export type ChargeGroupAccordionFragment = { __typename?: 'ChargeGroup', id: string, invoiceable: boolean, minAmountCents: any, payInAdvance: boolean, invoiceDisplayName?: string | null, properties: { __typename?: 'ChargeGroupsProperties', amount?: string | null }, charges?: Array<{ __typename?: 'Charge', id: string, chargeModel: ChargeModelEnum, invoiceable: boolean, minAmountCents: any, payInAdvance: boolean, prorated: boolean, invoiceDisplayName?: string | null, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, blockTimeInMinutes?: any | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null } }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null }> | null };
+
+export type ChargeGroupChildAccordionFragment = { __typename?: 'Charge', id: string, chargeModel: ChargeModelEnum, invoiceable: boolean, minAmountCents: any, payInAdvance: boolean, prorated: boolean, invoiceDisplayName?: string | null, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, blockTimeInMinutes?: any | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null } }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null };
+
 export type ChargeForChargeOptionsAccordionFragment = { __typename?: 'Charge', id: string, invoiceable: boolean, minAmountCents: any, payInAdvance: boolean };
 
 export type PercentageChargeFragment = { __typename?: 'Charge', id: string, properties?: { __typename?: 'Properties', fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, values: { __typename?: 'Properties', fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null } }> | null };
@@ -4601,7 +4605,7 @@ export type GetPlanForDetailsOverviewSectionQueryVariables = Exact<{
 }>;
 
 
-export type GetPlanForDetailsOverviewSectionQuery = { __typename?: 'Query', plan?: { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, payInAdvance: boolean, invoiceDisplayName?: string | null, amountCents: any, amountCurrency: CurrencyEnum, trialPeriod?: number | null, subscriptionsCount: number, billChargesMonthly?: boolean | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, charges?: Array<{ __typename?: 'Charge', id: string, minAmountCents: any, payInAdvance: boolean, chargeModel: ChargeModelEnum, invoiceable: boolean, prorated: boolean, invoiceDisplayName?: string | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, code: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, chargeGroup?: { __typename?: 'ChargeGroup', id: string, invoiceDisplayName?: string | null, minAmountCents: any, payInAdvance: boolean, invoiceable: boolean, usageChargeGroups?: Array<{ __typename?: 'UsageChargeGroup', id: string, properties: { __typename?: 'UsageChargeGroupsProperties', amount?: string | null } }> | null } | null, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, blockTimeInMinutes?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } }> | null }> | null } | null };
+export type GetPlanForDetailsOverviewSectionQuery = { __typename?: 'Query', plan?: { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, payInAdvance: boolean, invoiceDisplayName?: string | null, amountCents: any, amountCurrency: CurrencyEnum, trialPeriod?: number | null, subscriptionsCount: number, billChargesMonthly?: boolean | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, charges?: Array<{ __typename?: 'Charge', id: string, minAmountCents: any, payInAdvance: boolean, chargeModel: ChargeModelEnum, invoiceable: boolean, prorated: boolean, invoiceDisplayName?: string | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, code: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, chargeGroup?: { __typename?: 'ChargeGroup', id: string, invoiceDisplayName?: string | null, minAmountCents: any, payInAdvance: boolean, invoiceable: boolean, properties: { __typename?: 'ChargeGroupsProperties', amount?: string | null } } | null, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, blockTimeInMinutes?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } }> | null }> | null } | null };
 
 export type GetSubscribtionsForPlanDetailsQueryVariables = Exact<{
   page?: InputMaybe<Scalars['Int']['input']>;
@@ -4913,7 +4917,7 @@ export type GetSinglePlanQueryVariables = Exact<{
 }>;
 
 
-export type GetSinglePlanQuery = { __typename?: 'Query', plan?: { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, payInAdvance: boolean, invoiceDisplayName?: string | null, amountCents: any, amountCurrency: CurrencyEnum, trialPeriod?: number | null, subscriptionsCount: number, billChargesMonthly?: boolean | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, charges?: Array<{ __typename?: 'Charge', id: string, minAmountCents: any, payInAdvance: boolean, chargeModel: ChargeModelEnum, invoiceable: boolean, prorated: boolean, invoiceDisplayName?: string | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, code: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, chargeGroup?: { __typename?: 'ChargeGroup', id: string, invoiceDisplayName?: string | null, minAmountCents: any, payInAdvance: boolean, invoiceable: boolean, usageChargeGroups?: Array<{ __typename?: 'UsageChargeGroup', id: string, properties: { __typename?: 'UsageChargeGroupsProperties', amount?: string | null } }> | null } | null, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, blockTimeInMinutes?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } }> | null }> | null } | null };
+export type GetSinglePlanQuery = { __typename?: 'Query', plan?: { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, payInAdvance: boolean, invoiceDisplayName?: string | null, amountCents: any, amountCurrency: CurrencyEnum, trialPeriod?: number | null, subscriptionsCount: number, billChargesMonthly?: boolean | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, charges?: Array<{ __typename?: 'Charge', id: string, minAmountCents: any, payInAdvance: boolean, chargeModel: ChargeModelEnum, invoiceable: boolean, prorated: boolean, invoiceDisplayName?: string | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, code: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, chargeGroup?: { __typename?: 'ChargeGroup', id: string, invoiceDisplayName?: string | null, minAmountCents: any, payInAdvance: boolean, invoiceable: boolean, properties: { __typename?: 'ChargeGroupsProperties', amount?: string | null } } | null, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, blockTimeInMinutes?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } }> | null }> | null } | null };
 
 export type CreatePlanMutationVariables = Exact<{
   input: CreatePlanInput;
@@ -5179,7 +5183,7 @@ export type TaxForPlanAndChargesInPlanFormFragment = { __typename?: 'Tax', id: s
 
 export type BillableMetricForPlanFragment = { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null };
 
-export type EditPlanFragment = { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, payInAdvance: boolean, invoiceDisplayName?: string | null, amountCents: any, amountCurrency: CurrencyEnum, trialPeriod?: number | null, subscriptionsCount: number, billChargesMonthly?: boolean | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, charges?: Array<{ __typename?: 'Charge', id: string, minAmountCents: any, payInAdvance: boolean, chargeModel: ChargeModelEnum, invoiceable: boolean, prorated: boolean, invoiceDisplayName?: string | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, code: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, chargeGroup?: { __typename?: 'ChargeGroup', id: string, invoiceDisplayName?: string | null, minAmountCents: any, payInAdvance: boolean, invoiceable: boolean, usageChargeGroups?: Array<{ __typename?: 'UsageChargeGroup', id: string, properties: { __typename?: 'UsageChargeGroupsProperties', amount?: string | null } }> | null } | null, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, blockTimeInMinutes?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } }> | null }> | null };
+export type EditPlanFragment = { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, payInAdvance: boolean, invoiceDisplayName?: string | null, amountCents: any, amountCurrency: CurrencyEnum, trialPeriod?: number | null, subscriptionsCount: number, billChargesMonthly?: boolean | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, charges?: Array<{ __typename?: 'Charge', id: string, minAmountCents: any, payInAdvance: boolean, chargeModel: ChargeModelEnum, invoiceable: boolean, prorated: boolean, invoiceDisplayName?: string | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, code: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, chargeGroup?: { __typename?: 'ChargeGroup', id: string, invoiceDisplayName?: string | null, minAmountCents: any, payInAdvance: boolean, invoiceable: boolean, properties: { __typename?: 'ChargeGroupsProperties', amount?: string | null } } | null, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, blockTimeInMinutes?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } }> | null }> | null };
 
 export type AddSubscriptionPlanFragment = { __typename?: 'Plan', id: string, name: string, code: string, interval: PlanInterval };
 
@@ -5967,6 +5971,105 @@ export const InvoiceForVoidInvoiceDialogFragmentDoc = gql`
   number
 }
     `;
+export const TaxForPlanChargeAccordionFragmentDoc = gql`
+    fragment TaxForPlanChargeAccordion on Tax {
+  id
+  code
+  name
+  rate
+}
+    `;
+export const ChargeForChargeOptionsAccordionFragmentDoc = gql`
+    fragment ChargeForChargeOptionsAccordion on Charge {
+  id
+  invoiceable
+  minAmountCents
+  payInAdvance
+}
+    `;
+export const PackageGroupChargeFragmentDoc = gql`
+    fragment PackageGroupCharge on Charge {
+  id
+  properties {
+    amount
+    packageSize
+    freeUnits
+  }
+  groupProperties {
+    groupId
+    values {
+      amount
+      packageSize
+      freeUnits
+    }
+  }
+}
+    `;
+export const TimebasedChargeFragmentDoc = gql`
+    fragment TimebasedCharge on Charge {
+  id
+  properties {
+    amount
+    blockTimeInMinutes
+  }
+}
+    `;
+export const ChargeGroupChildAccordionFragmentDoc = gql`
+    fragment ChargeGroupChildAccordion on Charge {
+  id
+  chargeModel
+  invoiceable
+  minAmountCents
+  payInAdvance
+  prorated
+  invoiceDisplayName
+  properties {
+    amount
+  }
+  groupProperties {
+    groupId
+    invoiceDisplayName
+    values {
+      amount
+    }
+  }
+  billableMetric {
+    id
+    name
+    aggregationType
+    recurring
+    flatGroups {
+      id
+      key
+      value
+    }
+  }
+  taxes {
+    ...TaxForPlanChargeAccordion
+  }
+  ...ChargeForChargeOptionsAccordion
+  ...PackageGroupCharge
+  ...TimebasedCharge
+}
+    ${TaxForPlanChargeAccordionFragmentDoc}
+${ChargeForChargeOptionsAccordionFragmentDoc}
+${PackageGroupChargeFragmentDoc}
+${TimebasedChargeFragmentDoc}`;
+export const ChargeGroupAccordionFragmentDoc = gql`
+    fragment ChargeGroupAccordion on ChargeGroup {
+  id
+  invoiceable
+  minAmountCents
+  payInAdvance
+  invoiceDisplayName
+  properties {
+    amount
+  }
+  charges {
+    ...ChargeGroupChildAccordion
+  }
+}
+    ${ChargeGroupChildAccordionFragmentDoc}`;
 export const BillableMetricForChargeSectionFragmentDoc = gql`
     fragment billableMetricForChargeSection on BillableMetric {
   id
@@ -6863,14 +6966,6 @@ export const BillableMetricForPlanFragmentDoc = gql`
   }
 }
     `;
-export const TaxForPlanChargeAccordionFragmentDoc = gql`
-    fragment TaxForPlanChargeAccordion on Tax {
-  id
-  code
-  name
-  rate
-}
-    `;
 export const GraduatedChargeFragmentDoc = gql`
     fragment GraduatedCharge on Charge {
   id
@@ -6984,41 +7079,6 @@ export const PercentageChargeFragmentDoc = gql`
   }
 }
     `;
-export const ChargeForChargeOptionsAccordionFragmentDoc = gql`
-    fragment ChargeForChargeOptionsAccordion on Charge {
-  id
-  invoiceable
-  minAmountCents
-  payInAdvance
-}
-    `;
-export const PackageGroupChargeFragmentDoc = gql`
-    fragment PackageGroupCharge on Charge {
-  id
-  properties {
-    amount
-    packageSize
-    freeUnits
-  }
-  groupProperties {
-    groupId
-    values {
-      amount
-      packageSize
-      freeUnits
-    }
-  }
-}
-    `;
-export const TimebasedChargeFragmentDoc = gql`
-    fragment TimebasedCharge on Charge {
-  id
-  properties {
-    amount
-    blockTimeInMinutes
-  }
-}
-    `;
 export const ChargeAccordionFragmentDoc = gql`
     fragment ChargeAccordion on Charge {
   id
@@ -7058,7 +7118,6 @@ export const ChargeAccordionFragmentDoc = gql`
   ...PackageCharge
   ...PercentageCharge
   ...ChargeForChargeOptionsAccordion
-  ...PackageGroupCharge
   ...TimebasedCharge
 }
     ${TaxForPlanChargeAccordionFragmentDoc}
@@ -7068,7 +7127,6 @@ ${VolumeRangesFragmentDoc}
 ${PackageChargeFragmentDoc}
 ${PercentageChargeFragmentDoc}
 ${ChargeForChargeOptionsAccordionFragmentDoc}
-${PackageGroupChargeFragmentDoc}
 ${TimebasedChargeFragmentDoc}`;
 export const PlanForChargeAccordionFragmentDoc = gql`
     fragment PlanForChargeAccordion on Plan {
@@ -7142,11 +7200,8 @@ export const EditPlanFragmentDoc = gql`
       minAmountCents
       payInAdvance
       invoiceable
-      usageChargeGroups {
-        id
-        properties {
-          amount
-        }
+      properties {
+        amount
       }
     }
   }

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -5206,6 +5206,8 @@ export type TaxForPlanAndChargesInPlanFormFragment = { __typename?: 'Tax', id: s
 
 export type BillableMetricForPlanFragment = { __typename?: 'BillableMetric', id: string, name: string, code: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null };
 
+export type ChargeGroupForPlanFragment = { __typename?: 'ChargeGroup', id: string, invoiceDisplayName?: string | null, minAmountCents: any, payInAdvance: boolean, invoiceable: boolean, properties: { __typename?: 'ChargeGroupProperties', amount?: string | null } };
+
 export type EditPlanFragment = { __typename?: 'Plan', id: string, name: string, code: string, description?: string | null, interval: PlanInterval, payInAdvance: boolean, invoiceDisplayName?: string | null, amountCents: any, amountCurrency: CurrencyEnum, trialPeriod?: number | null, subscriptionsCount: number, billChargesMonthly?: boolean | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, charges?: Array<{ __typename?: 'Charge', id: string, minAmountCents: any, payInAdvance: boolean, chargeModel: ChargeModelEnum, invoiceable: boolean, prorated: boolean, invoiceDisplayName?: string | null, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, code: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, chargeGroup?: { __typename?: 'ChargeGroup', id: string, invoiceDisplayName?: string | null, minAmountCents: any, payInAdvance: boolean, invoiceable: boolean, properties: { __typename?: 'ChargeGroupProperties', amount?: string | null } } | null, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, blockTimeInMinutes?: any | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, fixedAmount?: string | null, freeUnitsPerEvents?: any | null, freeUnitsPerTotalAggregation?: string | null, rate?: string | null, perTransactionMinAmount?: string | null, perTransactionMaxAmount?: string | null, graduatedRanges?: Array<{ __typename?: 'GraduatedRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null, graduatedPercentageRanges?: Array<{ __typename?: 'GraduatedPercentageRange', flatAmount: string, fromValue: any, rate: string, toValue?: any | null }> | null, volumeRanges?: Array<{ __typename?: 'VolumeRange', flatAmount: string, fromValue: any, perUnitAmount: string, toValue?: any | null }> | null } }> | null }> | null, chargeGroups?: Array<{ __typename?: 'ChargeGroup', id: string, invoiceDisplayName?: string | null, minAmountCents: any, payInAdvance: boolean, invoiceable: boolean, properties: { __typename?: 'ChargeGroupProperties', amount?: string | null } }> | null };
 
 export type AddSubscriptionPlanFragment = { __typename?: 'Plan', id: string, name: string, code: string, interval: PlanInterval };
@@ -7178,6 +7180,18 @@ ${PackageChargeFragmentDoc}
 ${PercentageChargeFragmentDoc}
 ${ChargeForChargeOptionsAccordionFragmentDoc}
 ${TimebasedChargeFragmentDoc}`;
+export const ChargeGroupForPlanFragmentDoc = gql`
+    fragment chargeGroupForPlan on ChargeGroup {
+  id
+  invoiceDisplayName
+  minAmountCents
+  payInAdvance
+  invoiceable
+  properties {
+    amount
+  }
+}
+    `;
 export const PlanForChargeAccordionFragmentDoc = gql`
     fragment PlanForChargeAccordion on Plan {
   billChargesMonthly
@@ -7245,14 +7259,7 @@ export const EditPlanFragmentDoc = gql`
     ...ChargeAccordion
     chargeModel
     chargeGroup {
-      id
-      invoiceDisplayName
-      minAmountCents
-      payInAdvance
-      invoiceable
-      properties {
-        amount
-      }
+      ...chargeGroupForPlan
     }
   }
   chargeGroups {
@@ -7272,6 +7279,7 @@ export const EditPlanFragmentDoc = gql`
     ${TaxForPlanAndChargesInPlanFormFragmentDoc}
 ${BillableMetricForPlanFragmentDoc}
 ${ChargeAccordionFragmentDoc}
+${ChargeGroupForPlanFragmentDoc}
 ${PlanForChargeAccordionFragmentDoc}
 ${PlanForSettingsSectionFragmentDoc}
 ${PlanForFixedFeeSectionFragmentDoc}`;

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -4552,9 +4552,9 @@ export type GetTaxesForChargesQueryVariables = Exact<{
 
 export type GetTaxesForChargesQuery = { __typename?: 'Query', taxes: { __typename?: 'TaxCollection', metadata: { __typename?: 'CollectionMetadata', currentPage: number, totalPages: number }, collection: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> } };
 
-export type ChargeGroupAccordionFragment = { __typename?: 'ChargeGroup', id: string, invoiceDisplayName?: string | null, invoiceable: boolean, minAmountCents: any, payInAdvance: boolean, properties: { __typename?: 'ChargeGroupProperties', amount?: string | null }, charges?: Array<{ __typename?: 'Charge', id: string, chargeModel: ChargeModelEnum, invoiceable: boolean, minAmountCents: any, payInAdvance: boolean, prorated: boolean, invoiceDisplayName?: string | null, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, blockTimeInMinutes?: any | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null } }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null }> | null };
+export type ChargeGroupAccordionFragment = { __typename?: 'ChargeGroup', id: string, invoiceDisplayName?: string | null, invoiceable: boolean, minAmountCents: any, payInAdvance: boolean, properties: { __typename?: 'ChargeGroupProperties', amount?: string | null }, charges?: Array<{ __typename?: 'Charge', id: string, chargeModel: ChargeModelEnum, invoiceable: boolean, minAmountCents: any, payInAdvance: boolean, prorated: boolean, invoiceDisplayName?: string | null, properties?: { __typename?: 'Properties', packageSize?: any | null, freeUnits?: any | null, amount?: string | null, blockTimeInMinutes?: any | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null } }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null }> | null };
 
-export type ChargeGroupChildAccordionFragment = { __typename?: 'Charge', id: string, chargeModel: ChargeModelEnum, invoiceable: boolean, minAmountCents: any, payInAdvance: boolean, prorated: boolean, invoiceDisplayName?: string | null, properties?: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null, blockTimeInMinutes?: any | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null } }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null };
+export type ChargeGroupChildAccordionFragment = { __typename?: 'Charge', id: string, chargeModel: ChargeModelEnum, invoiceable: boolean, minAmountCents: any, payInAdvance: boolean, prorated: boolean, invoiceDisplayName?: string | null, properties?: { __typename?: 'Properties', packageSize?: any | null, freeUnits?: any | null, amount?: string | null, blockTimeInMinutes?: any | null } | null, groupProperties?: Array<{ __typename?: 'GroupProperties', groupId: string, invoiceDisplayName?: string | null, values: { __typename?: 'Properties', amount?: string | null, packageSize?: any | null, freeUnits?: any | null } }> | null, billableMetric: { __typename?: 'BillableMetric', id: string, name: string, aggregationType: AggregationTypeEnum, recurring: boolean, flatGroups?: Array<{ __typename?: 'Group', id: string, key?: string | null, value: string }> | null }, taxes?: Array<{ __typename?: 'Tax', id: string, code: string, name: string, rate: number }> | null };
 
 export type ChargeForChargeGroupOptionsAccordionFragment = { __typename?: 'Charge', id: string, invoiceable: boolean, minAmountCents: any, payInAdvance: boolean };
 
@@ -6010,8 +6010,8 @@ export const ChargeForChargeGroupOptionsAccordionFragmentDoc = gql`
   payInAdvance
 }
     `;
-export const PackageGroupChargeFragmentDoc = gql`
-    fragment PackageGroupCharge on Charge {
+export const PackageGroupChildChargeFragmentDoc = gql`
+    fragment PackageGroupChildCharge on Charge {
   id
   properties {
     amount
@@ -6047,7 +6047,8 @@ export const ChargeGroupChildAccordionFragmentDoc = gql`
   prorated
   invoiceDisplayName
   properties {
-    amount
+    packageSize
+    freeUnits
   }
   groupProperties {
     groupId
@@ -6071,12 +6072,12 @@ export const ChargeGroupChildAccordionFragmentDoc = gql`
     ...TaxForPlanChargeAccordion
   }
   ...ChargeForChargeGroupOptionsAccordion
-  ...PackageGroupCharge
+  ...PackageGroupChildCharge
   ...TimebasedCharge
 }
     ${TaxForPlanChargeAccordionFragmentDoc}
 ${ChargeForChargeGroupOptionsAccordionFragmentDoc}
-${PackageGroupChargeFragmentDoc}
+${PackageGroupChildChargeFragmentDoc}
 ${TimebasedChargeFragmentDoc}`;
 export const ChargeGroupAccordionFragmentDoc = gql`
     fragment ChargeGroupAccordion on ChargeGroup {
@@ -6107,8 +6108,8 @@ export const BillableMetricForChargeSectionFragmentDoc = gql`
   }
 }
     `;
-export const PackageGroupChildChargeFragmentDoc = gql`
-    fragment PackageGroupChildCharge on Charge {
+export const PackageGroupChargeFragmentDoc = gql`
+    fragment PackageGroupCharge on Charge {
   id
   properties {
     amount

--- a/src/hooks/plans/__tests__/useGraduatedChargeForm.test.tsx
+++ b/src/hooks/plans/__tests__/useGraduatedChargeForm.test.tsx
@@ -57,6 +57,7 @@ const prepare = async ({
                 : undefined,
           },
         ],
+        chargeGroups: [],
       },
       onSubmit: () => {},
     })

--- a/src/hooks/plans/__tests__/useGraduatedPercentageChargeForm.test.tsx
+++ b/src/hooks/plans/__tests__/useGraduatedPercentageChargeForm.test.tsx
@@ -60,6 +60,7 @@ const prepare = async ({
                 : undefined,
           },
         ],
+        chargeGroups: [],
       },
       onSubmit: () => {},
     })

--- a/src/hooks/plans/__tests__/useVolumeChargeForm.test.tsx
+++ b/src/hooks/plans/__tests__/useVolumeChargeForm.test.tsx
@@ -57,6 +57,7 @@ const prepare = async ({
                 : undefined,
           },
         ],
+        chargeGroups: [],
       },
       onSubmit: () => {},
     })

--- a/src/hooks/plans/usePlanForm.tsx
+++ b/src/hooks/plans/usePlanForm.tsx
@@ -147,6 +147,7 @@ export const usePlanForm: ({
               minAmountCents,
               payInAdvance,
               invoiceDisplayName,
+              chargeGroup,
               ...charge
             }) => ({
               // Used to not enable submit button on invoiceDisplayName reset
@@ -168,12 +169,13 @@ export const usePlanForm: ({
                     }
                   })
                 : [],
+              chargeGroup: chargeGroup || undefined,
               ...charge,
             }),
           )
         : ([] as LocalChargeInput[]),
       chargeGroups: plan?.chargeGroups
-        ? plan?.chargeGroups.map(
+        ? plan.chargeGroups.map(
             ({ properties, minAmountCents, invoiceDisplayName, payInAdvance, ...group }) => ({
               invoiceDisplayName: invoiceDisplayName || '',
               minAmountCents: isNaN(minAmountCents)

--- a/src/hooks/plans/usePlanForm.tsx
+++ b/src/hooks/plans/usePlanForm.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo } from 'react'
 import { generatePath, useNavigate, useParams } from 'react-router-dom'
 import { number, object, string } from 'yup'
 
-import { LocalChargeInput, PlanFormInput } from '~/components/plans/types'
+import { LocalChargeGroupInput, LocalChargeInput, PlanFormInput } from '~/components/plans/types'
 import { addToast, hasDefinedGQLError } from '~/core/apolloClient'
 import {
   PLAN_FORM_TYPE,
@@ -14,6 +14,7 @@ import {
 import { FORM_ERRORS_ENUM, FORM_TYPE_ENUM } from '~/core/constants/form'
 import { ERROR_404_ROUTE, PLAN_DETAILS_ROUTE } from '~/core/router'
 import { serializePlanInput } from '~/core/serializers'
+import getChargeGroupPropertyShape from '~/core/serializers/getChargeGroupPropertyShape'
 import getPropertyShape from '~/core/serializers/getPropertyShape'
 import { deserializeAmount } from '~/core/serializers/serializeAmount'
 import { chargeSchema } from '~/formValidation/chargeSchema'
@@ -171,6 +172,21 @@ export const usePlanForm: ({
             }),
           )
         : ([] as LocalChargeInput[]),
+      chargeGroups: plan?.chargeGroups
+        ? plan?.chargeGroups.map(
+            ({ properties, minAmountCents, invoiceDisplayName, payInAdvance, ...group }) => ({
+              invoiceDisplayName: invoiceDisplayName || '',
+              minAmountCents: isNaN(minAmountCents)
+                ? undefined
+                : String(
+                    deserializeAmount(minAmountCents || 0, plan.amountCurrency || CurrencyEnum.Usd),
+                  ),
+              payInAdvance: payInAdvance || false,
+              properties: properties ? getChargeGroupPropertyShape(properties) : undefined,
+              ...group,
+            }),
+          )
+        : ([] as LocalChargeGroupInput[]),
     },
     validationSchema: object().shape({
       name: string().required(''),

--- a/src/pages/CreatePlan.tsx
+++ b/src/pages/CreatePlan.tsx
@@ -57,6 +57,17 @@ gql`
     }
   }
 
+  fragment chargeGroupForPlan on ChargeGroup {
+    id
+    invoiceDisplayName
+    minAmountCents
+    payInAdvance
+    invoiceable
+    properties {
+      amount
+    }
+  }
+
   fragment EditPlan on Plan {
     id
     name
@@ -87,16 +98,8 @@ gql`
       }
       ...ChargeAccordion
       chargeModel
-      # TODO: Check to remove this
       chargeGroup {
-        id
-        invoiceDisplayName
-        minAmountCents
-        payInAdvance
-        invoiceable
-        properties {
-          amount
-        }
+        ...chargeGroupForPlan
       }
     }
     chargeGroups {

--- a/src/pages/CreatePlan.tsx
+++ b/src/pages/CreatePlan.tsx
@@ -87,6 +87,7 @@ gql`
       }
       ...ChargeAccordion
       chargeModel
+      # TODO: Check to remove this
       chargeGroup {
         id
         invoiceDisplayName
@@ -96,6 +97,16 @@ gql`
         properties {
           amount
         }
+      }
+    }
+    chargeGroups {
+      id
+      invoiceDisplayName
+      minAmountCents
+      payInAdvance
+      invoiceable
+      properties {
+        amount
       }
     }
 

--- a/src/pages/CreatePlan.tsx
+++ b/src/pages/CreatePlan.tsx
@@ -93,11 +93,8 @@ gql`
         minAmountCents
         payInAdvance
         invoiceable
-        usageChargeGroups {
-          id
-          properties {
-            amount
-          }
+        properties {
+          amount
         }
       }
     }

--- a/src/pages/CreatePlan.tsx
+++ b/src/pages/CreatePlan.tsx
@@ -87,6 +87,19 @@ gql`
       }
       ...ChargeAccordion
       chargeModel
+      chargeGroup {
+        id
+        invoiceDisplayName
+        minAmountCents
+        payInAdvance
+        invoiceable
+        usageChargeGroups {
+          id
+          properties {
+            amount
+          }
+        }
+      }
     }
 
     ...PlanForChargeAccordion


### PR DESCRIPTION
## Context
We want to be able to group different charges as a single group charge. For example, an AWS package of (80GB bandwidth + 5B storage) is counted as a single charge.

## Description
- Add `Charge group` UI for view plan
- Implement form flow to create a new charge group
  - A charge in this group can only be type of `package_group` or `time-based`
- Add `Charge group` UI in view/edit subscription

## Screenshots
View plan:
<img width="1440" alt="image" src="https://github.com/Pressingly/lago-front/assets/69509154/2bff5fe5-ca83-4ed9-b5dd-3f596e19cebe">
<img width="695" alt="image" src="https://github.com/Pressingly/lago-front/assets/69509154/e174d2ef-afcd-45c1-86d4-bbe25ba90bcd">

Create a plan:
<img width="754" alt="image" src="https://github.com/Pressingly/lago-front/assets/69509154/0acdc262-97cc-4f20-b0e7-7031a1ba8d51">
<img width="739" alt="image" src="https://github.com/Pressingly/lago-front/assets/69509154/75acf0cd-54df-4978-8cea-bfe18a35378d">
<img width="708" alt="image" src="https://github.com/Pressingly/lago-front/assets/69509154/f127e5b1-ef61-49e1-85b2-c7cee5b6b8be">

There can be multiple charges with different type in one plan:
<img width="752" alt="image" src="https://github.com/Pressingly/lago-front/assets/69509154/ca040c3a-ce4b-4a03-91ad-80ea1330e3e5">