### PR TITLE
Pinet Integration by using API certificate (private_key, key_id)

### DIFF
--- a/src/components/plans/types.ts
+++ b/src/components/plans/types.ts
@@ -1,7 +1,7 @@
 import {
   BillableMetricForPlanFragment,
-  ChargeGroupInput,
   ChargeGroupForPlanFragment,
+  ChargeGroupInput,
   ChargeInput,
   CreatePlanInput,
   TaxForPlanChargeAccordionFragment,

--- a/src/core/serializers/__tests__/serializePlanInput.test.ts
+++ b/src/core/serializers/__tests__/serializePlanInput.test.ts
@@ -70,7 +70,7 @@ describe('serializePlanInput()', () => {
         payInAdvance: true,
         trialPeriod: 1,
         taxCodes: [],
-        chargeGroups: []
+        chargeGroups: [],
       })
 
       expect(plan).toStrictEqual({
@@ -115,7 +115,7 @@ describe('serializePlanInput()', () => {
         payInAdvance: true,
         trialPeriod: 1,
         taxCodes: [],
-        chargeGroups: []
+        chargeGroups: [],
       })
 
       expect(plan).toStrictEqual({
@@ -193,7 +193,7 @@ describe('serializePlanInput()', () => {
         payInAdvance: true,
         trialPeriod: 1,
         taxCodes: [],
-        chargeGroups: []
+        chargeGroups: [],
       })
 
       expect(plan).toStrictEqual({
@@ -271,7 +271,7 @@ describe('serializePlanInput()', () => {
         payInAdvance: true,
         trialPeriod: 1,
         taxCodes: [],
-        chargeGroups: []
+        chargeGroups: [],
       })
 
       expect(plan).toStrictEqual({
@@ -337,7 +337,7 @@ describe('serializePlanInput()', () => {
         payInAdvance: true,
         trialPeriod: 1,
         taxCodes: [],
-        chargeGroups: []
+        chargeGroups: [],
       })
 
       expect(plan).toStrictEqual({
@@ -403,7 +403,7 @@ describe('serializePlanInput()', () => {
         payInAdvance: true,
         trialPeriod: 1,
         taxCodes: [],
-        chargeGroups: []
+        chargeGroups: [],
       })
 
       expect(plan).toStrictEqual({
@@ -469,7 +469,7 @@ describe('serializePlanInput()', () => {
         payInAdvance: true,
         trialPeriod: 1,
         taxCodes: [],
-        chargeGroups: []
+        chargeGroups: [],
       })
 
       expect(plan).toStrictEqual({

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -84,6 +84,8 @@ export type AddPinetPaymentProviderInput = {
   /** A unique identifier for the client performing the mutation. */
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
   createCustomers?: InputMaybe<Scalars['Boolean']['input']>;
+  keyId: Scalars['String']['input'];
+  privateKey: Scalars['String']['input'];
   secretKey?: InputMaybe<Scalars['String']['input']>;
   successRedirectUrl?: InputMaybe<Scalars['String']['input']>;
 };
@@ -3848,7 +3850,6 @@ export type UpdatePlanInput = {
   amountCents: Scalars['BigInt']['input'];
   amountCurrency: CurrencyEnum;
   billChargesMonthly?: InputMaybe<Scalars['Boolean']['input']>;
-  chargeGroups?: InputMaybe<Array<ChargeGroupInput>>;
   charges: Array<ChargeInput>;
   /** A unique identifier for the client performing the mutation. */
   clientMutationId?: InputMaybe<Scalars['String']['input']>;

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -2721,7 +2721,8 @@ export type PinetProvider = {
   __typename?: 'PinetProvider';
   createCustomers: Scalars['Boolean']['output'];
   id: Scalars['ID']['output'];
-  secretKey: Scalars['String']['output'];
+  keyId: Scalars['String']['output'];
+  privateKey: Scalars['String']['output'];
   successRedirectUrl?: Maybe<Scalars['String']['output']>;
 };
 
@@ -4806,7 +4807,7 @@ export type AddPinetApiKeyMutationVariables = Exact<{
 }>;
 
 
-export type AddPinetApiKeyMutation = { __typename?: 'Mutation', addPinetPaymentProvider?: { __typename?: 'PinetProvider', id: string, secretKey: string, createCustomers: boolean, successRedirectUrl?: string | null } | null };
+export type AddPinetApiKeyMutation = { __typename?: 'Mutation', addPinetPaymentProvider?: { __typename?: 'PinetProvider', id: string, keyId: string, privateKey: string, successRedirectUrl?: string | null } | null };
 
 export type AddStripeApiKeyMutationVariables = Exact<{
   input: AddStripePaymentProviderInput;
@@ -5542,19 +5543,19 @@ export type GetOrganizationInformationsQueryVariables = Exact<{ [key: string]: n
 
 export type GetOrganizationInformationsQuery = { __typename?: 'Query', organization?: { __typename?: 'Organization', id: string, logoUrl?: string | null, name: string, legalName?: string | null, legalNumber?: string | null, taxIdentificationNumber?: string | null, email?: string | null, addressLine1?: string | null, addressLine2?: string | null, zipcode?: string | null, city?: string | null, state?: string | null, country?: CountryCode | null, timezone?: TimezoneEnum | null } | null };
 
-export type PinetIntegrationFragment = { __typename?: 'PinetProvider', id: string, secretKey: string, createCustomers: boolean, successRedirectUrl?: string | null };
+export type PinetIntegrationFragment = { __typename?: 'PinetProvider', id: string, keyId: string, privateKey: string, successRedirectUrl?: string | null };
 
 export type PinetIntegrationsSettingQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type PinetIntegrationsSettingQuery = { __typename?: 'Query', organization?: { __typename?: 'Organization', id: string, pinetPaymentProvider?: { __typename?: 'PinetProvider', id: string, secretKey: string, createCustomers: boolean, successRedirectUrl?: string | null } | null } | null };
+export type PinetIntegrationsSettingQuery = { __typename?: 'Query', organization?: { __typename?: 'Organization', id: string, pinetPaymentProvider?: { __typename?: 'PinetProvider', id: string, keyId: string, privateKey: string, successRedirectUrl?: string | null } | null } | null };
 
 export type UpdatePinetIntegrationMutationVariables = Exact<{
   input: AddPinetPaymentProviderInput;
 }>;
 
 
-export type UpdatePinetIntegrationMutation = { __typename?: 'Mutation', addPinetPaymentProvider?: { __typename?: 'PinetProvider', id: string, secretKey: string, createCustomers: boolean, successRedirectUrl?: string | null } | null };
+export type UpdatePinetIntegrationMutation = { __typename?: 'Mutation', addPinetPaymentProvider?: { __typename?: 'PinetProvider', id: string, keyId: string, privateKey: string, successRedirectUrl?: string | null } | null };
 
 export type StripeIntegrationFragment = { __typename?: 'StripeProvider', id: string, secretKey: string, createCustomers: boolean, successRedirectUrl?: string | null };
 
@@ -7453,8 +7454,8 @@ export const OrganizationInformationsFragmentDoc = gql`
 export const PinetIntegrationFragmentDoc = gql`
     fragment PinetIntegration on PinetProvider {
   id
-  secretKey
-  createCustomers
+  keyId
+  privateKey
   successRedirectUrl
 }
     `;

--- a/src/pages/settings/PinetIntegration.tsx
+++ b/src/pages/settings/PinetIntegration.tsx
@@ -374,15 +374,6 @@ const ApiKey = styled(Typography)`
   margin-right: auto;
 `
 
-// const Title = styled.div`
-//   position: relative;
-//   height: ${NAV_HEIGHT}px;
-//   width: 100%;
-//   display: flex;
-//   align-items: center;
-//   justify-content: space-between;
-// `
-
 const LocalPopper = styled(Popper)`
   position: relative;
   height: 100%;

--- a/src/pages/settings/PinetIntegration.tsx
+++ b/src/pages/settings/PinetIntegration.tsx
@@ -108,63 +108,101 @@ const PinetIntegration = () => {
 
       <ContentWrapper>
         <section>
-          <Title variant="subhead">{translate('text_62b1edddbf5f461ab971273f')}</Title>
-          <ApiKeyItem>
+          <Title>
+            <Typography variant="subhead">{translate('text_645d071272418a14c1c76a9a')}</Typography>
+            <LocalPopper
+              PopperProps={{ placement: 'bottom-end' }}
+              opener={({ isOpen }) => (
+                <PopperOpener>
+                  <Tooltip
+                    placement="top-end"
+                    disableHoverListener={isOpen}
+                    title={translate('text_629728388c4d2300e2d3810d')}
+                  >
+                    <Button icon="dots-horizontal" variant="quaternary" />
+                  </Tooltip>
+                </PopperOpener>
+              )}
+            >
+              {({ closePopper }) => (
+                <MenuPopper>
+                  <Button
+                    startIcon="pen"
+                    variant="quaternary"
+                    fullWidth
+                    align="left"
+                    onClick={() => {
+                      addDialogRef.current?.openDialog()
+                    }}
+                  >
+                    {translate('text_62b1edddbf5f461ab9712787')}
+                  </Button>
+                  <Button
+                    startIcon="trash"
+                    variant="quaternary"
+                    align="left"
+                    fullWidth
+                    onClick={() => {
+                      deleteDialogRef.current?.openDialog()
+                      closePopper()
+                    }}
+                  >
+                    {translate('text_62b1edddbf5f461ab971279f')}
+                  </Button>
+                </MenuPopper>
+              )}
+            </LocalPopper>
+          </Title>
+          {/* <Title variant="subhead">{translate('text_62b1edddbf5f461ab971273f')}</Title> */}
+          <>
             {loading ? (
               <>
-                <Skeleton variant="connectorAvatar" size="big" marginRight="16px" />
-                <Skeleton variant="text" width={240} height={12} />
+                {[1, 2].map((i) => (
+                  <ApiKeyItem key={`item-skeleton-item-${i}`}>
+                    <Skeleton variant="connectorAvatar" size="big" marginRight="16px" />
+                    <Skeleton variant="text" width={240} height={12} />
+                  </ApiKeyItem>
+                ))}
               </>
             ) : (
               <>
-                <Avatar variant="connector" size="big">
-                  <Icon color="dark" name="key" />
-                </Avatar>
-                <ApiKey color="textSecondary">{pinetPaymentProvider?.secretKey}</ApiKey>
-                <Popper
-                  PopperProps={{ placement: 'bottom-end' }}
-                  opener={<Button icon="dots-horizontal" variant="quaternary" />}
-                >
-                  {({ closePopper }) => (
-                    <MenuPopper>
-                      <Button
-                        startIcon="pen"
-                        variant="quaternary"
-                        fullWidth
-                        align="left"
-                        onClick={() => {
-                          addDialogRef.current?.openDialog()
-                        }}
-                      >
-                        {translate('text_62b1edddbf5f461ab9712787')}
-                      </Button>
-                      <Button
-                        startIcon="trash"
-                        variant="quaternary"
-                        align="left"
-                        fullWidth
-                        onClick={() => {
-                          deleteDialogRef.current?.openDialog()
-                          closePopper()
-                        }}
-                      >
-                        {translate('text_62b1edddbf5f461ab971279f')}
-                      </Button>
-                    </MenuPopper>
-                  )}
-                </Popper>
+                <ApiKeyItem>
+                  <Avatar variant="connector" size="big">
+                    <Icon color="dark" name="key" />
+                  </Avatar>
+                  <div>
+                    <Typography variant="caption" color="grey600">
+                      {'Key ID'}
+                    </Typography>
+
+                  <ApiKey color="textSecondary">{pinetPaymentProvider?.secretKey}</ApiKey>
+                  </div>
+                </ApiKeyItem>
+                <ApiKeyItem>
+                  <Avatar variant="connector" size="big">
+                    <Icon name="bank" color="dark" />
+                  </Avatar>
+                  <div>
+                    <Typography variant="caption" color="grey600">
+                      Private Key
+                    </Typography>
+                    <Typography variant="body" color="grey700">
+                      {pinetPaymentProvider?.secretKey}
+                    </Typography>
+                  </div>
+                </ApiKeyItem>
               </>
             )}
-          </ApiKeyItem>
+          </>
           <Typography variant="caption" color="grey600">
             {
-              'This API secret key is used to connect PINET to Lago, edit it to make a new connection'
+              'This API certificate is used to connect PINET to Lago, edit it to make a new connection'
             }
           </Typography>
         </section>
 
         <section>
-          <InlineTitle>
+          <Title>
             <Typography variant="subhead">{translate('text_65367cb78324b77fcb6af21c')}</Typography>
             <Button
               variant="quaternary"
@@ -179,7 +217,7 @@ const PinetIntegration = () => {
             >
               {translate('text_65367cb78324b77fcb6af20e')}
             </Button>
-          </InlineTitle>
+          </Title>
 
           {loading ? (
             <ApiKeyItem>
@@ -303,6 +341,7 @@ const Title = styled(Typography)`
   width: 100%;
   display: flex;
   align-items: center;
+  justify-content: space-between;
 `
 
 const ApiKeyItem = styled.div`
@@ -335,14 +374,14 @@ const ApiKey = styled(Typography)`
   margin-right: auto;
 `
 
-const InlineTitle = styled.div`
-  position: relative;
-  height: ${NAV_HEIGHT}px;
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-`
+// const Title = styled.div`
+//   position: relative;
+//   height: ${NAV_HEIGHT}px;
+//   width: 100%;
+//   display: flex;
+//   align-items: center;
+//   justify-content: space-between;
+// `
 
 const LocalPopper = styled(Popper)`
   position: relative;

--- a/src/pages/settings/PinetIntegration.tsx
+++ b/src/pages/settings/PinetIntegration.tsx
@@ -175,7 +175,7 @@ const PinetIntegration = () => {
                       {'Key ID'}
                     </Typography>
 
-                  <ApiKey color="textSecondary">{pinetPaymentProvider?.keyId}</ApiKey>
+                    <ApiKey color="textSecondary">{pinetPaymentProvider?.keyId}</ApiKey>
                   </div>
                 </ApiKeyItem>
                 <ApiKeyItem>

--- a/src/pages/settings/PinetIntegration.tsx
+++ b/src/pages/settings/PinetIntegration.tsx
@@ -34,8 +34,8 @@ import { MenuPopper, NAV_HEIGHT, PageHeader, PopperOpener, theme } from '~/style
 gql`
   fragment PinetIntegration on PinetProvider {
     id
-    secretKey
-    createCustomers
+    keyId
+    privateKey
     successRedirectUrl
   }
 
@@ -175,7 +175,7 @@ const PinetIntegration = () => {
                       {'Key ID'}
                     </Typography>
 
-                  <ApiKey color="textSecondary">{pinetPaymentProvider?.secretKey}</ApiKey>
+                  <ApiKey color="textSecondary">{pinetPaymentProvider?.keyId}</ApiKey>
                   </div>
                 </ApiKeyItem>
                 <ApiKeyItem>
@@ -187,7 +187,7 @@ const PinetIntegration = () => {
                       Private Key
                     </Typography>
                     <Typography variant="body" color="grey700">
-                      {pinetPaymentProvider?.secretKey}
+                      {pinetPaymentProvider?.privateKey}
                     </Typography>
                   </div>
                 </ApiKeyItem>


### PR DESCRIPTION
## What
- Allow user use API certificate (that includes `key_id` and `private_key`) to integrate with PINET.

## Why
- This update base on https://github.com/Pressingly/PINET/discussions/31

## Screenshot
- Add dialog
<img width="1219" alt="image" src="https://github.com/Pressingly/lago-front/assets/45629756/b7ff88fe-ba35-4f47-9d8b-74a9100567d4">


- Edit dialog
<img width="622" alt="image" src="https://github.com/Pressingly/lago-front/assets/45629756/a3ee3d05-52e9-4214-aee0-6dddf99e17ab">
